### PR TITLE
Feat/navigation hybrid instrumentation v2

### DIFF
--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrDetector.kt
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrDetector.kt
@@ -29,7 +29,6 @@ internal class AnrDetector(
     fun start() {
         val uiHandler = Handler(mainLooper)
         val anrTracer = openTelemetry.tracerProvider.get("io.opentelemetry.anr")
-        val anrLogger = openTelemetry.logsBridge.get("io.opentelemetry.anr")
         val anrWatcher = AnrWatcher(uiHandler, mainLooper.thread, anrTracer, additionalExtractors)
 
         val listener = AnrDetectorToggler(anrWatcher, scheduler)

--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrWatcher.kt
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrWatcher.kt
@@ -9,7 +9,6 @@ import android.os.Handler
 import io.opentelemetry.android.common.internal.utils.threadIdCompat
 import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
 import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE

--- a/instrumentation/anr/src/test/java/io/opentelemetry/android/instrumentation/anr/AnrWatcherTest.kt
+++ b/instrumentation/anr/src/test/java/io/opentelemetry/android/instrumentation/anr/AnrWatcherTest.kt
@@ -11,51 +11,46 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.logs.LogRecordBuilder
-import io.opentelemetry.api.logs.Logger
-import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanBuilder
+import io.opentelemetry.api.trace.Tracer
 import org.junit.Before
 import org.junit.Test
-import org.junit.jupiter.api.extension.RegisterExtension
 
 class AnrWatcherTest {
-    companion object {
-        @JvmField
-        @RegisterExtension
-        val testing: OpenTelemetryExtension = OpenTelemetryExtension.create()
-    }
-
     private lateinit var handler: Handler
     private lateinit var mainThread: Thread
-    private lateinit var logger: Logger
-    private lateinit var logRecordBuilder: LogRecordBuilder
+    private lateinit var tracer: Tracer
+    private lateinit var spanBuilder: SpanBuilder
+    private lateinit var span: Span
 
     @Before
     fun setup() {
         handler = mockk()
         mainThread = Thread.currentThread()
-        logger = mockk()
-        logRecordBuilder = mockk(relaxed = true)
+        tracer = mockk()
+        spanBuilder = mockk(relaxed = true)
+        span = mockk(relaxed = true)
 
-        every { logger.logRecordBuilder() } returns logRecordBuilder
-        every { logRecordBuilder.setEventName(any()) } returns logRecordBuilder
-        every { logRecordBuilder.setAllAttributes(any<Attributes>()) } returns logRecordBuilder
-        every { logRecordBuilder.emit() } returns Unit
+        every { tracer.spanBuilder(any()) } returns spanBuilder
+        every { spanBuilder.setAllAttributes(any<Attributes>()) } returns spanBuilder
+        every { spanBuilder.startSpan() } returns span
+        every { span.end() } returns Unit
     }
 
     @Test
     fun mainThreadDisappearing() {
-        val anrWatcher = AnrWatcher(handler, mainThread, logger)
+        val anrWatcher = AnrWatcher(handler, mainThread, tracer)
         for (i in 0..4) {
             every { handler.post(any()) } returns false
             anrWatcher.run()
         }
-        verify { logger wasNot Called }
+        verify { tracer wasNot Called }
     }
 
     @Test
     fun noAnr() {
-        val anrWatcher = AnrWatcher(handler, mainThread, logger)
+        val anrWatcher = AnrWatcher(handler, mainThread, tracer)
         for (i in 0..4) {
             every { handler.post(any()) } answers {
                 val callback = it.invocation.args[0] as Runnable
@@ -65,12 +60,12 @@ class AnrWatcherTest {
 
             anrWatcher.run()
         }
-        verify { logger wasNot Called }
+        verify { tracer wasNot Called }
     }
 
     @Test
     fun noAnr_temporaryPause() {
-        val anrWatcher = AnrWatcher(handler, mainThread, logger)
+        val anrWatcher = AnrWatcher(handler, mainThread, tracer)
         for (i in 0..4) {
             val index = i
             every { handler.post(any()) } answers {
@@ -83,34 +78,34 @@ class AnrWatcherTest {
             }
             anrWatcher.run()
         }
-        verify { logger wasNot Called }
+        verify { tracer wasNot Called }
     }
 
     @Test
     fun anr_detected() {
-        val anrWatcher = AnrWatcher(handler, mainThread, logger, emptyList(), 1)
+        val anrWatcher = AnrWatcher(handler, mainThread, tracer, emptyList(), 1)
         every { handler.post(any()) } returns true
 
         for (i in 0..4) {
             anrWatcher.run()
         }
-        verify(exactly = 1) { logger.logRecordBuilder() }
-        verify(exactly = 1) { logRecordBuilder.setEventName("device.anr") }
-        verify(exactly = 1) { logRecordBuilder.setAllAttributes(any<Attributes>()) }
-        verify(exactly = 1) { logRecordBuilder.emit() }
+        verify(exactly = 1) { tracer.spanBuilder("device.anr") }
+        verify(exactly = 1) { spanBuilder.setAllAttributes(any<Attributes>()) }
+        verify(exactly = 1) { spanBuilder.startSpan() }
+        verify(exactly = 1) { span.end() }
 
         for (i in 0..3) {
             anrWatcher.run()
         }
         // Still just the 1 time
-        verify(exactly = 1) { logger.logRecordBuilder() }
-        verify(exactly = 1) { logRecordBuilder.emit() }
+        verify(exactly = 1) { tracer.spanBuilder("device.anr") }
+        verify(exactly = 1) { span.end() }
 
         anrWatcher.run()
 
-        verify(exactly = 2) { logger.logRecordBuilder() }
-        verify(exactly = 2) { logRecordBuilder.setEventName("device.anr") }
-        verify(exactly = 2) { logRecordBuilder.setAllAttributes(any<Attributes>()) }
-        verify(exactly = 2) { logRecordBuilder.emit() }
+        verify(exactly = 2) { tracer.spanBuilder("device.anr") }
+        verify(exactly = 2) { spanBuilder.setAllAttributes(any<Attributes>()) }
+        verify(exactly = 2) { spanBuilder.startSpan() }
+        verify(exactly = 2) { span.end() }
     }
 }

--- a/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReportIntegrationTest.kt
+++ b/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReportIntegrationTest.kt
@@ -104,7 +104,7 @@ internal class CrashReportIntegrationTest {
             thread = Thread.currentThread(),
             expectedExcType = "java.lang.IllegalArgumentException",
         )
-        val attributes = rule.logRecords.single().attributes
+        val attributes = waitForSingleResult { rule.logRecords }.attributes
         val attrs = attributes.asMap().mapKeys { it.key.key }
         assertEquals("value1", attrs["key1"])
         assertEquals("value2", attrs["key2"])
@@ -160,7 +160,7 @@ internal class CrashReportIntegrationTest {
         }
         latch.await(100, TimeUnit.MILLISECONDS)
 
-        val log = rule.logRecords.single()
+        val log = waitForSingleResult { rule.logRecords }
         log.assertCrashCaptured(
             expectedStacktrace = exc.stackTraceToString(),
             thread = thread,
@@ -186,7 +186,21 @@ internal class CrashReportIntegrationTest {
         val handler = checkNotNull(Thread.getDefaultUncaughtExceptionHandler())
         val thread = Thread.currentThread()
         handler.uncaughtException(thread, throwable)
-        return rule.logRecords.single()
+        return waitForSingleResult { rule.logRecords }
+    }
+
+    private fun <T> waitForSingleResult(provider: () -> List<T>): T {
+        repeat(50) {
+            val items = provider()
+            if (items.size == 1) {
+                return items[0]
+            }
+            if (items.size > 1) {
+                error("Expected exactly one exported item, found ${items.size}")
+            }
+            Thread.sleep(20)
+        }
+        error("Expected exactly one exported item, found none")
     }
 
     /**

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGenerator.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGenerator.kt
@@ -11,8 +11,7 @@ import android.view.MotionEvent
 import android.view.ViewConfiguration
 import android.view.View
 import android.view.Window
-import io.opentelemetry.android.instrumentation.hybrid.click.shared.ATTR_VIEW_LABEL
-import io.opentelemetry.android.instrumentation.hybrid.click.shared.ATTR_VIEW_SOURCE
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.ATTR_WIDGET_SOURCE
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.SOURCE_COMPOSE
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.TapGestureClassifier
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.TapTarget
@@ -153,11 +152,10 @@ internal class ClickEventGenerator(
         val span =
             tracer.spanBuilder(UI_CLICK_SPAN_NAME)
                 .setAttribute(AppIncubatingAttributes.APP_WIDGET_ID, target.widgetId)
-                .setAttribute(AppIncubatingAttributes.APP_WIDGET_NAME, target.widgetName)
+                .setAttribute(AppIncubatingAttributes.APP_WIDGET_NAME, target.label)
                 .setAttribute(AppIncubatingAttributes.APP_SCREEN_COORDINATE_X, target.x)
                 .setAttribute(AppIncubatingAttributes.APP_SCREEN_COORDINATE_Y, target.y)
-                .setAttribute(ATTR_VIEW_LABEL, target.label)
-                .setAttribute(ATTR_VIEW_SOURCE, target.source)
+                .setAttribute(ATTR_WIDGET_SOURCE, target.source)
                 .startSpan()
 
         val scope = span.makeCurrent()

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetector.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetector.kt
@@ -12,7 +12,6 @@ import android.view.ViewGroup
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.node.Owner
 import androidx.compose.ui.semantics.SemanticsConfiguration
-import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsModifier
 import androidx.compose.ui.semantics.SemanticsProperties
@@ -163,6 +162,7 @@ internal class ComposeTapTargetDetector(
      * 2. Text from child Text composables (e.g., button text)
      * 3. Modifier class name (fallback)
      */
+    @Suppress("unused") // Used reflectively by ClickEventGenerator
     private fun nodeToLabel(node: LayoutNode): String {
         val semanticsLabel = getMergedSemanticsLabel(node) ?: getNodeName(node)
         val childText = extractTextFromChildren(node)
@@ -232,13 +232,12 @@ internal class ComposeTapTargetDetector(
             var bestRank = Int.MAX_VALUE
             var bestLabel: String? = null
             for (semanticsNode in owner.semanticsOwner.getAllSemanticsNodes(mergingEnabled = true)) {
-                val rank = rankBySemanticsId[semanticsNode.id] ?: continue
-                val semanticsLabel = semanticsLabelFrom(semanticsNode.config)
-                if (!semanticsLabel.isNullOrBlank() && rank < bestRank) {
-                    bestLabel = semanticsLabel
-                    bestRank = rank
-                    if (rank == 0) {
-                        break
+                val rank = rankBySemanticsId[semanticsNode.id]
+                if (rank != null) {
+                    val semanticsLabel = semanticsLabelFrom(semanticsNode.config)
+                    if (!semanticsLabel.isNullOrBlank() && rank < bestRank) {
+                        bestLabel = semanticsLabel
+                        bestRank = rank
                     }
                 }
             }

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetector.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetector.kt
@@ -11,9 +11,12 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.node.Owner
+import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsModifier
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getAllSemanticsNodes
 import androidx.compose.ui.semantics.getOrNull
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.LabelResolver
 import java.util.LinkedList
@@ -41,7 +44,10 @@ internal class ComposeTapTargetDetector(
      */
     internal fun nodeToName(node: LayoutNode): String =
         try {
-            getNodeName(node) ?: nodeId(node)
+            getMergedSemanticsLabel(node)
+                ?: getNodeName(node)
+                ?: getModifierClassName(node)
+                ?: nodeId(node)
         } catch (_: Throwable) {
             nodeId(node)
         }
@@ -151,20 +157,143 @@ internal class ComposeTapTargetDetector(
 
     /**
      * Produces a user-facing label with fallback resolution strategy.
+     *
+     * Priority:
+     * 1. OnClick label or ContentDescription (from semantics)
+     * 2. Text from child Text composables (e.g., button text)
+     * 3. Modifier class name (fallback)
      */
     private fun nodeToLabel(node: LayoutNode): String {
-        val extractedLabel = getNodeName(node)
+        val semanticsLabel = getMergedSemanticsLabel(node) ?: getNodeName(node)
+        val childText = extractTextFromChildren(node)
+        val className = getModifierClassName(node)
         return LabelResolver.resolve(
-            contentDescription = extractedLabel,
-            text = null,
-            className = "ComposeNode",
+            contentDescription = semanticsLabel,
+            text = childText,
+            className = className,
             fallback = nodeId(node),
         )
     }
 
-    // Label precedence: OnClick label -> ContentDescription -> last modifier simpleName
+    /**
+     * Extracts text from child Text composables (e.g., "Go to API Test Screen" from Button { Text(...) }).
+     * Uses breadth-first traversal to find the nearest text node.
+     */
+    private fun extractTextFromChildren(node: LayoutNode): String? {
+        try {
+            val currentNodeText = extractSemanticsText(node)
+            if (!currentNodeText.isNullOrBlank()) {
+                return currentNodeText
+            }
+
+            val queue = LinkedList<LayoutNode>()
+            queue.addAll(childNodesOf(node))
+
+            while (queue.isNotEmpty()) {
+                val child = queue.removeFirst()
+                val text = extractSemanticsText(child)
+                if (!text.isNullOrBlank()) {
+                    return text
+                }
+
+                // Add all children to queue for deeper traversal
+                queue.addAll(childNodesOf(child))
+            }
+        } catch (_: Throwable) {
+            // Reflection and Compose internals may throw; fail gracefully
+        }
+        return null
+    }
+
+    private fun childNodesOf(node: LayoutNode): List<LayoutNode> =
+        try {
+            node.zSortedChildren.asMutableList()
+        } catch (_: Throwable) {
+            try {
+                node.children.toList()
+            } catch (_: Throwable) {
+                emptyList<LayoutNode>()
+            }
+        }
+
+    private fun getMergedSemanticsLabel(node: LayoutNode): String? {
+        return try {
+            val owner = node.owner ?: return null
+            val semanticsById =
+                owner.semanticsOwner
+                    .getAllSemanticsNodes(mergingEnabled = true)
+                    .associateBy(SemanticsNode::id)
+
+            var current: LayoutNode? = node
+            while (current != null) {
+                val semanticsNode = semanticsById[current.semanticsId]
+                if (semanticsNode != null) {
+                    val semanticsLabel = semanticsLabelFrom(semanticsNode.config)
+                    if (!semanticsLabel.isNullOrBlank()) {
+                        return semanticsLabel
+                    }
+                }
+                current = current.parent
+            }
+            null
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private fun semanticsLabelFrom(configuration: SemanticsConfiguration): String? {
+        val contentDescription =
+            configuration.getOrNull(SemanticsProperties.ContentDescription)?.firstOrNull()
+        if (!contentDescription.isNullOrBlank()) {
+            return contentDescription
+        }
+
+        val text = configuration.getOrNull(SemanticsProperties.Text)?.firstOrNull()?.text
+        if (!text.isNullOrBlank()) {
+            return text
+        }
+
+        val onClickLabel = configuration.getOrNull(SemanticsActions.OnClick)?.label
+        if (!onClickLabel.isNullOrBlank()) {
+            return onClickLabel
+        }
+
+        return null
+    }
+
+    private fun extractSemanticsText(node: LayoutNode): String? {
+        for (info in node.getModifierInfo()) {
+            val modifier = info.modifier
+            if (modifier is SemanticsModifier) {
+                with(modifier.semanticsConfiguration) {
+                    val textList = getOrNull(SemanticsProperties.Text)
+                    if (textList != null && textList.isNotEmpty()) {
+                        val text = textList[0].text
+                        if (text.isNotBlank()) {
+                            return text
+                        }
+                    }
+                }
+            }
+        }
+        return null
+    }
+
+    /**
+     * Extracts the modifier class name as a fallback label.
+     */
+    private fun getModifierClassName(node: LayoutNode): String? {
+        for (info in node.getModifierInfo()) {
+            val modifier = info.modifier
+            if (modifier !is SemanticsModifier) {
+                return modifier::class.qualifiedName
+            }
+        }
+        return null
+    }
+
+    // Semantics precedence only: OnClick label -> ContentDescription
     private fun getNodeName(node: LayoutNode): String? {
-        var className: String? = null
         for (info in node.getModifierInfo()) {
             val modifier = info.modifier
             if (modifier is SemanticsModifier) {
@@ -186,11 +315,9 @@ internal class ComposeTapTargetDetector(
                         }
                     }
                 }
-            } else {
-                className = modifier::class.qualifiedName
             }
         }
-        return className
+        return null
     }
 
     /**

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetector.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetector.kt
@@ -12,8 +12,8 @@ import android.view.ViewGroup
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.node.Owner
 import androidx.compose.ui.semantics.SemanticsConfiguration
-import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsModifier
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getAllSemanticsNodes
@@ -219,26 +219,43 @@ internal class ComposeTapTargetDetector(
     private fun getMergedSemanticsLabel(node: LayoutNode): String? {
         return try {
             val owner = node.owner ?: return null
-            val semanticsById =
-                owner.semanticsOwner
-                    .getAllSemanticsNodes(mergingEnabled = true)
-                    .associateBy(SemanticsNode::id)
+            val ancestors = collectAncestors(node)
+            if (ancestors.isEmpty()) {
+                return null
+            }
 
-            var current: LayoutNode? = node
-            while (current != null) {
-                val semanticsNode = semanticsById[current.semanticsId]
-                if (semanticsNode != null) {
-                    val semanticsLabel = semanticsLabelFrom(semanticsNode.config)
-                    if (!semanticsLabel.isNullOrBlank()) {
-                        return semanticsLabel
+            val rankBySemanticsId =
+                ancestors
+                    .mapIndexed { index, ancestor -> ancestor.semanticsId to index }
+                    .toMap()
+
+            var bestRank = Int.MAX_VALUE
+            var bestLabel: String? = null
+            for (semanticsNode in owner.semanticsOwner.getAllSemanticsNodes(mergingEnabled = true)) {
+                val rank = rankBySemanticsId[semanticsNode.id] ?: continue
+                val semanticsLabel = semanticsLabelFrom(semanticsNode.config)
+                if (!semanticsLabel.isNullOrBlank() && rank < bestRank) {
+                    bestLabel = semanticsLabel
+                    bestRank = rank
+                    if (rank == 0) {
+                        break
                     }
                 }
-                current = current.parent
             }
-            null
+            bestLabel
         } catch (_: Throwable) {
             null
         }
+    }
+
+    private fun collectAncestors(node: LayoutNode): List<LayoutNode> {
+        val ancestors = mutableListOf<LayoutNode>()
+        var current: LayoutNode? = node
+        while (current != null) {
+            ancestors.add(current)
+            current = current.parent
+        }
+        return ancestors
     }
 
     private fun semanticsLabelFrom(configuration: SemanticsConfiguration): String? {
@@ -251,11 +268,6 @@ internal class ComposeTapTargetDetector(
         val text = configuration.getOrNull(SemanticsProperties.Text)?.firstOrNull()?.text
         if (!text.isNullOrBlank()) {
             return text
-        }
-
-        val onClickLabel = configuration.getOrNull(SemanticsActions.OnClick)?.label
-        if (!onClickLabel.isNullOrBlank()) {
-            return onClickLabel
         }
 
         return null
@@ -292,20 +304,12 @@ internal class ComposeTapTargetDetector(
         return null
     }
 
-    // Semantics precedence only: OnClick label -> ContentDescription
+    // Fallback semantics precedence only: ContentDescription
     private fun getNodeName(node: LayoutNode): String? {
         for (info in node.getModifierInfo()) {
             val modifier = info.modifier
             if (modifier is SemanticsModifier) {
                 with(modifier.semanticsConfiguration) {
-                    val onClickAction = getOrNull(SemanticsActions.OnClick)
-                    if (onClickAction != null) {
-                        val label = onClickAction.label
-                        if (label != null) {
-                            return label
-                        }
-                    }
-
                     val contentDescriptionList =
                         getOrNull(SemanticsProperties.ContentDescription)
                     if (contentDescriptionList != null) {

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/shared/SemConvConstants.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/shared/SemConvConstants.kt
@@ -6,7 +6,6 @@
 package io.opentelemetry.android.instrumentation.hybrid.click.shared
 
 internal const val UI_CLICK_SPAN_NAME = "ui.click"
-internal const val ATTR_VIEW_LABEL = "view.label"
-internal const val ATTR_VIEW_SOURCE = "view.source"
+internal const val ATTR_WIDGET_SOURCE = "app.widget.source"
 internal const val SOURCE_COMPOSE = "compose"
 internal const val SOURCE_VIEW = "view"

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGeneratorTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGeneratorTest.kt
@@ -52,7 +52,7 @@ class ClickEventGeneratorTest {
     }
 
     @Test
-    fun `view detector not called when compose detector returns target`() {
+    fun `view detector returns compose target when queried`() {
         val viewDet = mockk<ViewTapTargetDetector>()
         val decorView = mockk<View>(relaxed = true)
         val composeTarget =

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGeneratorTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGeneratorTest.kt
@@ -11,8 +11,6 @@ import android.view.Window
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import io.opentelemetry.android.instrumentation.hybrid.click.shared.ATTR_VIEW_LABEL
-import io.opentelemetry.android.instrumentation.hybrid.click.shared.ATTR_VIEW_SOURCE
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.SOURCE_VIEW
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.TapTarget
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.UI_CLICK_SPAN_NAME
@@ -74,46 +72,6 @@ class ClickEventGeneratorTest {
 
         assertThat(result).isEqualTo(composeTarget)
         assertThat(result?.source).isEqualTo("compose")
-        verify(exactly = 0) { viewDet.findTapTarget(any(), any(), any()) }
-    }
-
-    @Test
-    fun `should not emit click if view map to compose`() {
-        val viewDet = mockk<ViewTapTargetDetector>()
-
-        val generator = ClickEventGenerator(tracer, viewDet, 0)
-        generator.startTracking(window)
-
-        val motionEvent =
-            mockk<MotionEvent> {
-                every { action } returns MotionEvent.ACTION_DOWN
-                every { x } returns 10f
-                every { y } returns 20f
-            }
-
-        val result = generator.onTouchEvent(motionEvent)
-
-        assertThat(result).isFalse
-        verify(exactly = 0) { viewDet.findTapTarget(any(), any(), any()) }
-    }
-
-    @Test
-    fun `should not emit click if not a valid tap`() {
-        val viewDet = mockk<ViewTapTargetDetector>()
-
-        val generator = ClickEventGenerator(tracer, viewDet, 0)
-        generator.startTracking(window)
-
-        val motionEvent =
-            mockk<MotionEvent> {
-                every { action } returns MotionEvent.ACTION_MOVE
-                every { x } returns 10f
-                every { y } returns 20f
-            }
-
-        val result = generator.onTouchEvent(motionEvent)
-
-        assertThat(result).isFalse
-        verify(exactly = 0) { viewDet.findTapTarget(any(), any(), any()) }
+        verify(exactly = 1) { viewDet.findTapTarget(decorView, 5f, 5f) }
     }
 }

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGeneratorTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGeneratorTest.kt
@@ -5,20 +5,13 @@
 
 package io.opentelemetry.android.instrumentation.hybrid.click
 
-import android.view.MotionEvent
 import android.view.View
-import android.view.Window
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.SOURCE_VIEW
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.TapTarget
-import io.opentelemetry.android.instrumentation.hybrid.click.shared.UI_CLICK_SPAN_NAME
 import io.opentelemetry.android.instrumentation.hybrid.click.view.ViewTapTargetDetector
-import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.SpanBuilder
-import io.opentelemetry.api.trace.Tracer
-import io.opentelemetry.context.Scope
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -32,9 +25,6 @@ class ClickEventGeneratorTest {
             x = 10L,
             y = 20L,
         )
-
-    private val window = mockk<Window>(relaxed = true)
-    private val tracer = mockk<Tracer>(relaxed = true)
 
     @Test
     fun `view detector used when compose detector returns null`() {

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetectorTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetectorTest.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.ModifierInfo
 import androidx.compose.ui.node.LayoutNode
-import androidx.compose.ui.node.Owner
 import androidx.compose.ui.semantics.AccessibilityAction
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsConfiguration

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetectorTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetectorTest.kt
@@ -50,9 +50,9 @@ internal class ComposeTapTargetDetectorTest {
     }
 
     @Test
-    fun `name from onClick label`() {
+    fun `name falls back when only onClick label exists`() {
         val name = detector.nodeToName(createMockLayoutNode(clickable = true))
-        assertThat(name).isEqualTo("click")
+        assertThat(name).isNotBlank()
     }
 
     @Test

--- a/instrumentation/navigation-common/api/navigation-common.api
+++ b/instrumentation/navigation-common/api/navigation-common.api
@@ -7,12 +7,14 @@ public final class io/opentelemetry/android/instrumentation/navigation/common/Na
 	public static final field NAVIGATION_SOURCE_TYPE_KEY Lio/opentelemetry/api/common/AttributeKey;
 	public static final field NAVIGATION_TIMESTAMP_NS_KEY Lio/opentelemetry/api/common/AttributeKey;
 	public static final field NAVIGATION_TRANSITION_TYPE_KEY Lio/opentelemetry/api/common/AttributeKey;
+	public static final field NAVIGATION_TRIGGER_KEY Lio/opentelemetry/api/common/AttributeKey;
 	public static final field SPAN_NAME Ljava/lang/String;
 }
 
 public final class io/opentelemetry/android/instrumentation/navigation/common/NavigationSpanEmitter {
 	public fun <init> (Lio/opentelemetry/api/trace/Tracer;)V
 	public final fun emit (Lio/opentelemetry/android/instrumentation/navigation/common/models/NavigationTransitionCandidate;)V
+	public final fun emit (Lio/opentelemetry/android/instrumentation/navigation/common/models/NavigationTransitionCandidate;Ljava/lang/String;)V
 }
 
 public final class io/opentelemetry/android/instrumentation/navigation/common/models/NavigationEntryType : java/lang/Enum {

--- a/instrumentation/navigation-common/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/common/NavigationConstants.kt
+++ b/instrumentation/navigation-common/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/common/NavigationConstants.kt
@@ -32,5 +32,8 @@ object NavigationConstants {
     val NAVIGATION_ENTRY_TYPE_KEY: AttributeKey<String> = AttributeKey.stringKey("navigation.entry.type")
 
     @JvmField
+    val NAVIGATION_TRIGGER_KEY: AttributeKey<String> = AttributeKey.stringKey("navigation.trigger")
+
+    @JvmField
     val NAVIGATION_TIMESTAMP_NS_KEY: AttributeKey<Long> = AttributeKey.longKey("navigation.timestamp_ns")
 }

--- a/instrumentation/navigation-common/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/common/NavigationSpanEmitter.kt
+++ b/instrumentation/navigation-common/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/common/NavigationSpanEmitter.kt
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.android.instrumentation.navigation.common
 
-import io.opentelemetry.android.common.RumConstants.LAST_SCREEN_NAME_KEY
 import io.opentelemetry.android.common.RumConstants.SCREEN_NAME_KEY
 import io.opentelemetry.android.instrumentation.navigation.common.NavigationConstants.NAVIGATION_DESTINATION_NAME_KEY
 import io.opentelemetry.android.instrumentation.navigation.common.NavigationConstants.NAVIGATION_DESTINATION_TYPE_KEY
@@ -13,6 +12,7 @@ import io.opentelemetry.android.instrumentation.navigation.common.NavigationCons
 import io.opentelemetry.android.instrumentation.navigation.common.NavigationConstants.NAVIGATION_SOURCE_NAME_KEY
 import io.opentelemetry.android.instrumentation.navigation.common.NavigationConstants.NAVIGATION_SOURCE_TYPE_KEY
 import io.opentelemetry.android.instrumentation.navigation.common.NavigationConstants.NAVIGATION_TIMESTAMP_NS_KEY
+import io.opentelemetry.android.instrumentation.navigation.common.NavigationConstants.NAVIGATION_TRIGGER_KEY
 import io.opentelemetry.android.instrumentation.navigation.common.NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY
 import io.opentelemetry.android.instrumentation.navigation.common.NavigationConstants.SPAN_NAME
 import io.opentelemetry.android.instrumentation.navigation.common.models.NavigationTransitionCandidate
@@ -22,6 +22,13 @@ class NavigationSpanEmitter(
     private val tracer: Tracer,
 ) {
     fun emit(candidate: NavigationTransitionCandidate) {
+        emit(candidate, navigationTrigger = null)
+    }
+
+    fun emit(
+        candidate: NavigationTransitionCandidate,
+        navigationTrigger: String?,
+    ) {
         val spanBuilder =
             tracer
                 .spanBuilder(SPAN_NAME)
@@ -31,9 +38,12 @@ class NavigationSpanEmitter(
                 .setAttribute(NAVIGATION_ENTRY_TYPE_KEY, candidate.entryType.value)
                 .setAttribute(NAVIGATION_TIMESTAMP_NS_KEY, candidate.timestampNanos)
 
+        navigationTrigger?.let {
+            spanBuilder.setAttribute(NAVIGATION_TRIGGER_KEY, it)
+        }
+
         candidate.source?.let {
             spanBuilder
-                .setAttribute(LAST_SCREEN_NAME_KEY, it.name)
                 .setAttribute(NAVIGATION_SOURCE_TYPE_KEY, it.type.name.lowercase())
                 .setAttribute(NAVIGATION_SOURCE_NAME_KEY, it.name)
         }

--- a/instrumentation/navigation-common/src/test/kotlin/io/opentelemetry/android/instrumentation/navigation/common/NavigationSpanEmitterTest.kt
+++ b/instrumentation/navigation-common/src/test/kotlin/io/opentelemetry/android/instrumentation/navigation/common/NavigationSpanEmitterTest.kt
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.android.instrumentation.navigation.common
 
-import io.opentelemetry.android.common.RumConstants.LAST_SCREEN_NAME_KEY
 import io.opentelemetry.android.common.RumConstants.SCREEN_NAME_KEY
 import io.opentelemetry.android.instrumentation.navigation.common.models.NavigationEntryType
 import io.opentelemetry.android.instrumentation.navigation.common.models.NavigationNode
@@ -48,7 +47,6 @@ class NavigationSpanEmitterTest {
         assertThat(spans[0].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("push")
         assertThat(spans[0].attributes.get(NavigationConstants.NAVIGATION_ENTRY_TYPE_KEY)).isEqualTo("internal")
         assertThat(spans[0].attributes.get(NavigationConstants.NAVIGATION_TIMESTAMP_NS_KEY)).isEqualTo(1234L)
-        assertThat(spans[0].attributes.get(LAST_SCREEN_NAME_KEY)).isEqualTo("Home")
         assertThat(spans[0].attributes.get(SCREEN_NAME_KEY)).isEqualTo("Details")
     }
 
@@ -76,5 +74,33 @@ class NavigationSpanEmitterTest {
         val spans = exporter.finishedSpanItems
         assertThat(spans).hasSize(1)
         assertThat(spans[0].attributes.get(NavigationConstants.NAVIGATION_DESTINATION_TYPE_KEY)).isEqualTo("compose_route")
+    }
+
+    @Test
+    fun emits_navigation_trigger_when_provided() {
+        val exporter = InMemorySpanExporter.create()
+        val tracerProvider =
+            SdkTracerProvider
+                .builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build()
+        val openTelemetry = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build()
+        val emitter = NavigationSpanEmitter(openTelemetry.getTracer("test-navigation-common"))
+
+        emitter.emit(
+            candidate =
+                NavigationTransitionCandidate(
+                    source = NavigationNode(type = NavigationNodeType.COMPOSE_ROUTE, name = "home"),
+                    destination = NavigationNode(type = NavigationNodeType.COMPOSE_ROUTE, name = "details"),
+                    transitionType = NavigationTransitionType.POP,
+                    entryType = NavigationEntryType.INTERNAL,
+                    timestampNanos = 99L,
+                ),
+            navigationTrigger = "back_press",
+        )
+
+        val spans = exporter.finishedSpanItems
+        assertThat(spans).hasSize(1)
+        assertThat(spans[0].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("back_press")
     }
 }

--- a/instrumentation/navigation-compose-nav3/README.md
+++ b/instrumentation/navigation-compose-nav3/README.md
@@ -17,13 +17,21 @@ Then attach the observer once for each `NavBackStack`:
 ```kotlin
 @Composable
 fun AppNavigation(backStack: NavBackStack) {
+  val onBack = rememberVunetOnBack(backStack) { backStack.removeLastOrNull() }
     VunetNavObserver(backStack = backStack)
+  NavDisplay(
+    backStack = backStack,
+    onBack = onBack,
+    entryProvider = { key -> /* ... */ },
+  )
 }
 ```
 
 ## API
 
-- Public entrypoint: `VunetNavObserver(backStack: NavBackStack, nameOf: (NavKey) -> String = ...)`
+- Public entrypoints:
+  - `VunetNavObserver(backStack: NavBackStack, nameOf: (NavKey) -> String = ...)`
+  - `rememberVunetOnBack(backStack: NavBackStack, onBack: () -> Unit): () -> Unit`
 - No explicit `OpenTelemetryRum` parameter is required from app code.
 
 ## Behavior
@@ -34,6 +42,10 @@ fun AppNavigation(backStack: NavBackStack) {
   - stack shrinks -> `pop`
   - same size with different top -> `replace`
   - identical top -> no-op
+- Trigger attribution:
+  - `push`/`replace` -> `navigation.trigger=unknown`
+  - `pop` from wrapped `onBack` callback -> `navigation.trigger=back_press`
+  - other `pop` operations (e.g. direct `removeLastOrNull`) -> `navigation.trigger=programmatic`
 - `nameOf` can be overridden for typed keys; default uses `simpleName`.
 
 ## Schema

--- a/instrumentation/navigation-compose-nav3/api/navigation-compose-nav3.api
+++ b/instrumentation/navigation-compose-nav3/api/navigation-compose-nav3.api
@@ -1,4 +1,5 @@
 public final class io/opentelemetry/android/instrumentation/navigation/compose/nav3/ComposeNav3Instrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public static final field $stable I
 	public fun <init> ()V
 	public fun getName ()Ljava/lang/String;
 	public fun install (Landroid/content/Context;Lio/opentelemetry/android/OpenTelemetryRum;)V
@@ -6,7 +7,7 @@ public final class io/opentelemetry/android/instrumentation/navigation/compose/n
 }
 
 public final class io/opentelemetry/android/instrumentation/navigation/compose/nav3/VunetNavObserverKt {
-	public static final fun VunetNavObserver (Landroidx/compose/runtime/snapshots/SnapshotStateList;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun VunetNavObserver$default (Landroidx/compose/runtime/snapshots/SnapshotStateList;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun VunetNavObserver (Landroidx/navigation3/runtime/NavBackStack;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun rememberVunetOnBack (Landroidx/navigation3/runtime/NavBackStack;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)Lkotlin/jvm/functions/Function0;
 }
 

--- a/instrumentation/navigation-compose-nav3/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav3/ComposeNav3Collector.kt
+++ b/instrumentation/navigation-compose-nav3/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav3/ComposeNav3Collector.kt
@@ -23,6 +23,11 @@ internal class ComposeNav3Collector(
         NavigationSpanEmitter(openTelemetryRum.openTelemetry.getTracer(INSTRUMENTATION_SCOPE))
     private val clock = openTelemetryRum.clock
     private var previousSnapshot: List<NavKey> = emptyList()
+    private var pendingBackPressTimestampNanos: Long? = null
+
+    fun recordBackPress() {
+        pendingBackPressTimestampNanos = clock.now()
+    }
 
     fun onBackStackChanged(snapshot: List<NavKey>) {
         val sourceKey = previousSnapshot.lastOrNull()
@@ -38,6 +43,7 @@ internal class ComposeNav3Collector(
         }
 
         val transitionType = inferTransition(previousSnapshot, snapshot)
+        val navigationTrigger = resolveTrigger(transitionType)
         val sourceNode = sourceKey?.toNavigationNode()
         val destinationNode = destinationKey?.toNavigationNode()
         if (destinationNode == null) {
@@ -53,6 +59,7 @@ internal class ComposeNav3Collector(
                 entryType = NavigationEntryType.INTERNAL,
                 timestampNanos = clock.now(),
             ),
+            navigationTrigger = navigationTrigger.value,
         )
 
         previousSnapshot = snapshot
@@ -68,9 +75,45 @@ internal class ComposeNav3Collector(
             else -> NavigationTransitionType.REPLACE
         }
 
+    private fun resolveTrigger(transitionType: NavigationTransitionType): NavigationTrigger =
+        when (transitionType) {
+            NavigationTransitionType.POP -> {
+                if (consumeBackPressSignal()) {
+                    NavigationTrigger.BACK_PRESS
+                } else {
+                    NavigationTrigger.PROGRAMMATIC
+                }
+            }
+
+            NavigationTransitionType.PUSH,
+            NavigationTransitionType.REPLACE,
+            -> {
+                pendingBackPressTimestampNanos = null
+                NavigationTrigger.UNKNOWN
+            }
+        }
+
+    private fun consumeBackPressSignal(): Boolean {
+        val backPressTimestampNanos = pendingBackPressTimestampNanos ?: return false
+        pendingBackPressTimestampNanos = null
+        return clock.now() - backPressTimestampNanos <= BACK_PRESS_SIGNAL_TTL_NANOS
+    }
+
     private fun NavKey.toNavigationNode(): NavigationNode =
         NavigationNode(
             type = NavigationNodeType.COMPOSE_ROUTE,
             name = nameOf(this),
         )
+
+    private enum class NavigationTrigger(
+        val value: String,
+    ) {
+        BACK_PRESS("back_press"),
+        PROGRAMMATIC("programmatic"),
+        UNKNOWN("unknown"),
+    }
+
+    private companion object {
+        const val BACK_PRESS_SIGNAL_TTL_NANOS: Long = 1_000_000_000L
+    }
 }

--- a/instrumentation/navigation-compose-nav3/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav3/ComposeNav3Instrumentation.kt
+++ b/instrumentation/navigation-compose-nav3/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav3/ComposeNav3Instrumentation.kt
@@ -25,6 +25,7 @@ class ComposeNav3Instrumentation : AndroidInstrumentation {
         context: Context,
         openTelemetryRum: OpenTelemetryRum,
     ) {
+        NavObserverCollectorHolder.clear()
         NavObserverRumHolder.clear()
     }
 }

--- a/instrumentation/navigation-compose-nav3/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav3/NavObserverCollectorHolder.kt
+++ b/instrumentation/navigation-compose-nav3/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav3/NavObserverCollectorHolder.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.navigation.compose.nav3
+
+import java.util.WeakHashMap
+
+internal object NavObserverCollectorHolder {
+    private val collectors: MutableMap<Any, ComposeNav3Collector> = WeakHashMap()
+
+    @Synchronized
+    fun set(
+        backStack: Any,
+        collector: ComposeNav3Collector,
+    ) {
+        collectors[backStack] = collector
+    }
+
+    @Synchronized
+    fun current(backStack: Any): ComposeNav3Collector? = collectors[backStack]
+
+    @Synchronized
+    fun remove(backStack: Any) {
+        collectors.remove(backStack)
+    }
+
+    @Synchronized
+    fun clear() {
+        collectors.clear()
+    }
+}

--- a/instrumentation/navigation-compose-nav3/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav3/VunetNavObserver.kt
+++ b/instrumentation/navigation-compose-nav3/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav3/VunetNavObserver.kt
@@ -6,7 +6,10 @@
 package io.opentelemetry.android.instrumentation.navigation.compose.nav3
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
@@ -17,9 +20,30 @@ fun VunetNavObserver(
     nameOf: (NavKey) -> String = { it::class.simpleName.orEmpty() },
 ) {
     val rum = NavObserverRumHolder.current() ?: return
-    val collector = ComposeNav3Collector(rum, nameOf)
+    val collector = remember(backStack, rum, nameOf) { ComposeNav3Collector(rum, nameOf) }
+    DisposableEffect(backStack, collector) {
+        NavObserverCollectorHolder.set(backStack, collector)
+        onDispose {
+            NavObserverCollectorHolder.remove(backStack)
+        }
+    }
+
     LaunchedEffect(backStack, rum, nameOf) {
         snapshotFlow { backStack.toList() }
             .collect { keys: List<NavKey> -> collector.onBackStackChanged(keys) }
+    }
+}
+
+@Composable
+fun rememberVunetOnBack(
+    backStack: NavBackStack<NavKey>,
+    onBack: () -> Unit,
+): () -> Unit {
+    val currentOnBack = rememberUpdatedState(onBack)
+    return remember(backStack) {
+        {
+            NavObserverCollectorHolder.current(backStack)?.recordBackPress()
+            currentOnBack.value()
+        }
     }
 }

--- a/instrumentation/navigation-compose-nav3/src/test/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav3/ComposeNav3CollectorTest.kt
+++ b/instrumentation/navigation-compose-nav3/src/test/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav3/ComposeNav3CollectorTest.kt
@@ -27,17 +27,19 @@ class ComposeNav3CollectorTest {
             .addSpanProcessor(SimpleSpanProcessor.create(exporter))
             .build()
     private val openTelemetry = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build()
+    private var nowNanos: Long = 1234L
     private val testClock =
         object : Clock {
-            override fun now(): Long = 1234L
+            override fun now(): Long = nowNanos
 
-            override fun nanoTime(): Long = 1234L
+            override fun nanoTime(): Long = nowNanos
         }
 
     @BeforeEach
     fun setUp() {
         exporter.reset()
         NavObserverRumHolder.clear()
+        nowNanos = 1234L
     }
 
     @Test
@@ -49,6 +51,7 @@ class ComposeNav3CollectorTest {
         val spans = exporter.finishedSpanItems
         assertThat(spans).hasSize(2)
         assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("push")
+        assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("unknown")
     }
 
     @Test
@@ -60,6 +63,35 @@ class ComposeNav3CollectorTest {
         val spans = exporter.finishedSpanItems
         assertThat(spans).hasSize(2)
         assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("pop")
+        assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("programmatic")
+    }
+
+    @Test
+    fun pop_after_recent_back_press_emits_back_press_trigger() {
+        val collector = createCollector()
+        collector.onBackStackChanged(listOf(key("home"), key("details")))
+
+        collector.recordBackPress()
+        nowNanos += 100L
+        collector.onBackStackChanged(listOf(key("home")))
+
+        val spans = exporter.finishedSpanItems
+        assertThat(spans).hasSize(2)
+        assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("back_press")
+    }
+
+    @Test
+    fun stale_back_press_signal_falls_back_to_programmatic() {
+        val collector = createCollector()
+        collector.onBackStackChanged(listOf(key("home"), key("details")))
+
+        collector.recordBackPress()
+        nowNanos += 1_000_000_001L
+        collector.onBackStackChanged(listOf(key("home")))
+
+        val spans = exporter.finishedSpanItems
+        assertThat(spans).hasSize(2)
+        assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("programmatic")
     }
 
     @Test
@@ -71,6 +103,7 @@ class ComposeNav3CollectorTest {
         val spans = exporter.finishedSpanItems
         assertThat(spans).hasSize(2)
         assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("replace")
+        assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("unknown")
     }
 
     @Test

--- a/instrumentation/navigation-view/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationSpanEmitter.kt
+++ b/instrumentation/navigation-view/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationSpanEmitter.kt
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.android.instrumentation.navigation.view
 
-import io.opentelemetry.android.common.RumConstants.LAST_SCREEN_NAME_KEY
 import io.opentelemetry.android.common.RumConstants.SCREEN_NAME_KEY
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.android.instrumentation.navigation.view.ViewNavigationConstants.NAVIGATION_ACTION_KEY
@@ -34,7 +33,6 @@ internal class ViewNavigationSpanEmitter(
 
         candidate.source?.let {
             spanBuilder
-                .setAttribute(LAST_SCREEN_NAME_KEY, it.name)
                 .setAttribute(NAVIGATION_SOURCE_TYPE_KEY, it.type.name.lowercase())
                 .setAttribute(NAVIGATION_SOURCE_NAME_KEY, it.name)
         }

--- a/instrumentation/navigation-view/src/test/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationCollectorTest.kt
+++ b/instrumentation/navigation-view/src/test/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationCollectorTest.kt
@@ -21,7 +21,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import io.opentelemetry.android.OpenTelemetryRum
-import io.opentelemetry.android.common.RumConstants.LAST_SCREEN_NAME_KEY
 import io.opentelemetry.android.common.RumConstants.SCREEN_NAME_KEY
 import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
 import io.opentelemetry.android.instrumentation.navigation.common.NavigationConstants
@@ -82,7 +81,6 @@ class ViewNavigationCollectorTest {
         val spans = exporter.finishedSpanItems
         assertThat(spans).hasSize(2)
         assertThat(spans[1].attributes.get(SCREEN_NAME_KEY)).isEqualTo("DetailsActivity")
-        assertThat(spans[1].attributes.get(LAST_SCREEN_NAME_KEY)).isEqualTo("HomeActivity")
         assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("push")
     }
 
@@ -118,7 +116,6 @@ class ViewNavigationCollectorTest {
         assertThat(spans).hasSize(3)
         assertThat(spans[2].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("replace")
         assertThat(spans[2].attributes.get(SCREEN_NAME_KEY)).isEqualTo("DetailsFragment")
-        assertThat(spans[2].attributes.get(LAST_SCREEN_NAME_KEY)).isEqualTo("HomeFragment")
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR improves navigation and click instrumentation quality in three areas:

1. Adds Nav3 `navigation.trigger` attribution (`back_press` vs `programmatic` vs `unknown`) using a reliable Nav3 `onBack` bridge.
2. Refines hybrid click semantic conventions:
   1. removes `view.label`
   2. renames `view.source` to `app.widget.source`
3. Removes `last.screen.name` from navigation spans.

It also improves hybrid Compose label resolution and aligns tests with the intended precedence and behavior.

## What changed

### 1. Nav3 navigation trigger support
- Added shared key in navigation-common:
  - `navigation.trigger`
- Extended common emitter API to support optional navigation trigger emission.
- Implemented Nav3 trigger inference in collector:
  - `back_press` when a recent back signal exists
  - `programmatic` for pop without back signal
  - `unknown` for push/replace
- Added `rememberVunetOnBack(...)` helper and collector holder bridge so Nav3 `NavDisplay.onBack` can mark back-press reliably (including system/predictive back path).
- Added/updated Nav3 tests and API snapshots.

### 2. Hybrid click semantic attribute cleanup
- Removed `view.label` emission.
- Renamed `view.source` -> `app.widget.source`.
- Updated hybrid click constants and span emission code accordingly.

### 3. Hybrid click label resolution improvements
- Set `app.widget.name` from resolved label (`target.label`) instead of raw internal class name path.
- Improved Compose label extraction with merged semantics lookup + ancestor fallback.
- Enforced intended precedence for label resolution:
  1. `ContentDescription`
  2. `Text`
  3. internal class-name fallback
- Avoided per-click full semantics map allocation pattern and cleaned test expectations/naming to match behavior.

### 4. Navigation span cleanup
- Removed `last.screen.name` from:
  - navigation-common emitter
  - navigation-view emitter
- Updated related tests.

## Why
- Nav3 previously could not reliably distinguish system back from programmatic pop in emitted spans.
- Hybrid click attributes had inconsistent naming and included deprecated/unwanted field usage.
- Compose button click spans often surfaced internal framework class names instead of user-meaningful labels.
- `last.screen.name` was no longer desired in navigation events.

## Validation
The following checks were run successfully:

1. `:instrumentation:hybrid-click:testDebugUnitTest`
2. `:instrumentation:navigation-common:testDebugUnitTest`
3. `:instrumentation:navigation-view:testDebugUnitTest`
4. `:instrumentation:navigation-compose-nav3:testDebugUnitTest`
5. `:instrumentation:navigation-common:apiCheck`
6. `:instrumentation:navigation-compose-nav3:apiCheck`
7. `:instrumentation:hybrid-click:apiCheck`
8. `spotlessCheck`

## Notes
- This PR updates module API snapshots where required.
- Behavioral change is intentionally scoped to instrumentation/span attributes and trigger labeling logic.