### PR TITLE
Standardize lifecycle and app.start span naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### ⚠️⚠️ Breaking changes
+
+- Activity and fragment lifecycle spans now use stable span names with an event attribute:
+  - Activity lifecycle: span name `activity.lifecycle`, attribute `activity.lifecycle.event` (`Created`, `Resumed`, `Paused`, `Stopped`, `Destroyed`, `Restarted`)
+  - Fragment lifecycle: span name `fragment.lifecycle`, attribute `fragment.lifecycle.event` (`Created`, `Restored`, `Resumed`, `Paused`, `Stopped`, `Destroyed`, `ViewDestroyed`, `Detached`)
+  - App startup span renamed from `AppStart` to `app.start` (`RumConstants.APP_START_SPAN_NAME`)
+  - Span events (`activityPreCreated`, `fragmentResumed`, etc.) are unchanged
+
 ## Version 1.3.0 (2026-04-22)
 
 ### ⚠️⚠️ Breaking changes

--- a/common/api/common.api
+++ b/common/api/common.api
@@ -1,6 +1,10 @@
 public final class io/opentelemetry/android/common/RumConstants {
+	public static final field ACTIVITY_LIFECYCLE_EVENT_KEY Lio/opentelemetry/api/common/AttributeKey;
+	public static final field ACTIVITY_LIFECYCLE_SPAN_NAME Ljava/lang/String;
 	public static final field APP_START_SPAN_NAME Ljava/lang/String;
 	public static final field BATTERY_PERCENT_KEY Lio/opentelemetry/api/common/AttributeKey;
+	public static final field FRAGMENT_LIFECYCLE_EVENT_KEY Lio/opentelemetry/api/common/AttributeKey;
+	public static final field FRAGMENT_LIFECYCLE_SPAN_NAME Ljava/lang/String;
 	public static final field HEAP_FREE_KEY Lio/opentelemetry/api/common/AttributeKey;
 	public static final field INSTANCE Lio/opentelemetry/android/common/RumConstants;
 	public static final field LAST_SCREEN_NAME_KEY Lio/opentelemetry/api/common/AttributeKey;

--- a/common/src/main/java/io/opentelemetry/android/common/RumConstants.kt
+++ b/common/src/main/java/io/opentelemetry/android/common/RumConstants.kt
@@ -28,7 +28,19 @@ object RumConstants {
     @JvmField
     val BATTERY_PERCENT_KEY: AttributeKey<Double> = AttributeKey.doubleKey("battery.percent")
 
-    const val APP_START_SPAN_NAME: String = "AppStart"
+    const val APP_START_SPAN_NAME: String = "app.start"
+
+    const val ACTIVITY_LIFECYCLE_SPAN_NAME: String = "activity.lifecycle"
+
+    @JvmField
+    val ACTIVITY_LIFECYCLE_EVENT_KEY: AttributeKey<String> =
+        AttributeKey.stringKey("activity.lifecycle.event")
+
+    const val FRAGMENT_LIFECYCLE_SPAN_NAME: String = "fragment.lifecycle"
+
+    @JvmField
+    val FRAGMENT_LIFECYCLE_EVENT_KEY: AttributeKey<String> =
+        AttributeKey.stringKey("fragment.lifecycle.event")
 
     object Events {
         const val INIT_EVENT_STARTED: String = "rum.sdk.init.started"

--- a/instrumentation/activity/README.md
+++ b/instrumentation/activity/README.md
@@ -14,7 +14,7 @@ This instrumentation produces the following telemetry:
 ### Application Start
 
 * Type: Span
-* Name: `AppStart`
+* Name: `app.start`
 * Description: This span is created and started when the Activity instrumentation is
   installed. It is ended when the initial activity reaches PostPaused, PostStopped, or PostDestroyed.
 * Attributes:
@@ -23,7 +23,7 @@ This instrumentation produces the following telemetry:
 ### Activity state change
 
 * Type: Span
-* Name: {`Created` | `Resumed` | `Paused` | `Stopped` | `Destroyed` | `Restarted` |} (depends on the activity state transition)
+* Name: `activity.lifecycle`
 * Description: As the activity transitions between states, a span will be created to represent the
   lifecycle of that state. Events are added for subsequent minor state changes.
 * SpanEvents: {
@@ -34,6 +34,7 @@ This instrumentation produces the following telemetry:
   `activityPreStopped` | `activityStopped` | `activityPostStopped` |
   `activityPreDestroyed` | `activityDestroyed` | `activityPostDestroyed` }
 * Attributes:
+  * `activity.lifecycle.event`: { `Created` | `Resumed` | `Paused` | `Stopped` | `Destroyed` | `Restarted` }
   * `activity.name`:  name of activity
   * `screen.name`:  name of screen
   * `last.screen.name`:  name of screen, only when span contains the `activityPostResumed` event.

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityTracer.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityTracer.kt
@@ -6,6 +6,8 @@
 package io.opentelemetry.android.instrumentation.activity
 
 import android.app.Activity
+import io.opentelemetry.android.common.RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY
+import io.opentelemetry.android.common.RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME
 import io.opentelemetry.android.common.RumConstants.APP_START_SPAN_NAME
 import io.opentelemetry.android.common.RumConstants.SCREEN_NAME_KEY
 import io.opentelemetry.android.common.RumConstants.START_TYPE_KEY
@@ -27,11 +29,11 @@ internal class ActivityTracer(
     private val screenName: String = screenName ?: "unknown_screen"
     private val activityName = activity.javaClass.simpleName
 
-    fun startSpanIfNoneInProgress(spanName: String): ActivityTracer {
+    fun startSpanIfNoneInProgress(lifecycleEvent: String): ActivityTracer {
         if (activeSpan.spanInProgress()) {
             return this
         }
-        activeSpan.startSpan { createSpan(spanName) }
+        activeSpan.startSpan { createLifecycleSpan(lifecycleEvent) }
         return this
     }
 
@@ -47,12 +49,12 @@ internal class ActivityTracer(
         // the activity class name as the base of the span name.
         val isColdStart = initialAppActivity == null
         if (isColdStart) {
-            return createSpanWithParent("Created", appStartupTimer.startupSpan)
+            return createLifecycleSpanWithParent("Created", appStartupTimer.startupSpan)
         }
         if (activityName == initialAppActivity) {
             return createAppStartSpan("warm")
         }
-        return createSpan("Created")
+        return createLifecycleSpan("Created")
     }
 
     fun initiateRestartSpanIfNecessary(multiActivityApp: Boolean): ActivityTracer {
@@ -70,22 +72,32 @@ internal class ActivityTracer(
         if (!multiActivityApp && activityName == initialAppActivity) {
             return createAppStartSpan("hot")
         }
-        return createSpan("Restarted")
+        return createLifecycleSpan("Restarted")
     }
 
     private fun createAppStartSpan(startType: String): Span {
-        val span = createSpan(APP_START_SPAN_NAME)
+        val span =
+            tracer
+                .spanBuilder(APP_START_SPAN_NAME)
+                .setAttribute(ACTIVITY_NAME_KEY, activityName)
+                .startSpan()
         span.setAttribute(START_TYPE_KEY, startType)
+        span.setAttribute(SCREEN_NAME_KEY, screenName)
         return span
     }
 
-    private fun createSpan(spanName: String): Span = createSpanWithParent(spanName, null)
+    private fun createLifecycleSpan(lifecycleEvent: String): Span =
+        createLifecycleSpanWithParent(lifecycleEvent, null)
 
-    private fun createSpanWithParent(
-        spanName: String,
+    private fun createLifecycleSpanWithParent(
+        lifecycleEvent: String,
         parentSpan: Span?,
     ): Span {
-        val spanBuilder = tracer.spanBuilder(spanName).setAttribute(ACTIVITY_NAME_KEY, activityName)
+        val spanBuilder =
+            tracer
+                .spanBuilder(ACTIVITY_LIFECYCLE_SPAN_NAME)
+                .setAttribute(ACTIVITY_NAME_KEY, activityName)
+                .setAttribute(ACTIVITY_LIFECYCLE_EVENT_KEY, lifecycleEvent)
         if (parentSpan != null) {
             spanBuilder.setParent(parentSpan.storeInContext(Context.current()))
         }

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer.kt
@@ -44,7 +44,7 @@ internal class AppStartupTimer {
         firstPossibleTimestamp = startupClock.now()
         val appStart =
             tracer
-                .spanBuilder("AppStart")
+                .spanBuilder(RumConstants.APP_START_SPAN_NAME)
                 .setStartTimestamp(firstPossibleTimestamp, TimeUnit.NANOSECONDS)
                 .setAttribute(RumConstants.START_TYPE_KEY, "cold")
                 .startSpan()

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityCallbacksTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityCallbacksTest.kt
@@ -96,7 +96,7 @@ internal class ActivityCallbacksTest {
 
         val span = spans[0]
 
-        assertEquals("AppStart", span.name)
+        assertEquals(RumConstants.APP_START_SPAN_NAME, span.name)
         assertEquals("warm", span.attributes.get(RumConstants.START_TYPE_KEY))
         assertEquals(
             activity.javaClass.simpleName,
@@ -145,7 +145,7 @@ internal class ActivityCallbacksTest {
 
         val span = spans[0]
 
-        assertEquals("AppStart", span.name)
+        assertEquals(RumConstants.APP_START_SPAN_NAME, span.name)
         assertEquals("hot", span.attributes.get(RumConstants.START_TYPE_KEY))
         assertEquals(
             activity.javaClass.simpleName,
@@ -185,7 +185,8 @@ internal class ActivityCallbacksTest {
 
         val span = spans[0]
 
-        assertEquals("Resumed", span.name)
+        assertEquals(RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME, span.name)
+        assertEquals("Resumed", span.attributes.get(RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY))
         assertEquals(
             activity.javaClass.simpleName,
             span.attributes.get(ActivityTracer.ACTIVITY_NAME_KEY),
@@ -222,7 +223,8 @@ internal class ActivityCallbacksTest {
 
         val span = spans[0]
 
-        assertEquals("Destroyed", span.name)
+        assertEquals(RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME, span.name)
+        assertEquals("Destroyed", span.attributes.get(RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY))
         assertEquals(
             activity.javaClass.simpleName,
             span.attributes.get(ActivityTracer.ACTIVITY_NAME_KEY),
@@ -256,7 +258,8 @@ internal class ActivityCallbacksTest {
 
         val stoppedSpan = spans[0]
 
-        assertEquals("Stopped", stoppedSpan.name)
+        assertEquals(RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME, stoppedSpan.name)
+        assertEquals("Stopped", stoppedSpan.attributes.get(RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY))
         assertEquals(
             activity.javaClass.simpleName,
             stoppedSpan.attributes.get(ActivityTracer.ACTIVITY_NAME_KEY),
@@ -276,7 +279,8 @@ internal class ActivityCallbacksTest {
 
         val destroyedSpan = spans[1]
 
-        assertEquals("Destroyed", destroyedSpan.name)
+        assertEquals(RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME, destroyedSpan.name)
+        assertEquals("Destroyed", destroyedSpan.attributes.get(RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY))
         assertEquals(
             activity.javaClass.simpleName,
             destroyedSpan.attributes.get(ActivityTracer.ACTIVITY_NAME_KEY),
@@ -310,7 +314,8 @@ internal class ActivityCallbacksTest {
 
         val stoppedSpan = spans[0]
 
-        assertEquals("Paused", stoppedSpan.name)
+        assertEquals(RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME, stoppedSpan.name)
+        assertEquals("Paused", stoppedSpan.attributes.get(RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY))
         assertEquals(
             activity.javaClass.simpleName,
             stoppedSpan.attributes.get(ActivityTracer.ACTIVITY_NAME_KEY),
@@ -330,7 +335,8 @@ internal class ActivityCallbacksTest {
 
         val destroyedSpan = spans[1]
 
-        assertEquals("Stopped", destroyedSpan.name)
+        assertEquals(RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME, destroyedSpan.name)
+        assertEquals("Stopped", destroyedSpan.attributes.get(RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY))
         assertEquals(
             activity.javaClass.simpleName,
             destroyedSpan.attributes.get(ActivityTracer.ACTIVITY_NAME_KEY),

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentationTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentationTest.kt
@@ -50,7 +50,7 @@ class ActivityLifecycleInstrumentationTest {
         val startupSpan: Span = mockk()
 
         every { openTelemetry.getTracer("io.opentelemetry.lifecycle") }.returns(tracer)
-        every { tracer.spanBuilder("AppStart") }.returns(startupSpanBuilder)
+        every { tracer.spanBuilder(RumConstants.APP_START_SPAN_NAME) }.returns(startupSpanBuilder)
         every { startupSpanBuilder.setStartTimestamp(any(), any()) }.returns(startupSpanBuilder)
         every { startupSpanBuilder.setAttribute(RumConstants.START_TYPE_KEY, "cold") }.returns(
             startupSpanBuilder,
@@ -64,7 +64,7 @@ class ActivityLifecycleInstrumentationTest {
         activityLifecycleInstrumentation.install(application, openTelemetryRum)
 
         verify {
-            tracer.spanBuilder("AppStart")
+            tracer.spanBuilder(RumConstants.APP_START_SPAN_NAME)
         }
         verify {
             startupSpanBuilder.setAttribute(RumConstants.START_TYPE_KEY, "cold")

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityTracerTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityTracerTest.kt
@@ -59,7 +59,8 @@ class ActivityTracerTest {
         trackableTracer.initiateRestartSpanIfNecessary(false)
         trackableTracer.endActiveSpan()
         val span = this.singleSpan
-        assertEquals("Restarted", span.name)
+        assertEquals(RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME, span.name)
+        assertEquals("Restarted", span.attributes.get(RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY))
         assertNull(span.attributes.get(RumConstants.START_TYPE_KEY))
     }
 
@@ -76,7 +77,7 @@ class ActivityTracerTest {
         trackableTracer.initiateRestartSpanIfNecessary(false)
         trackableTracer.endActiveSpan()
         val span = this.singleSpan
-        assertEquals("AppStart", span.name)
+        assertEquals(RumConstants.APP_START_SPAN_NAME, span.name)
         assertEquals("hot", span.attributes.get(RumConstants.START_TYPE_KEY))
     }
 
@@ -93,7 +94,8 @@ class ActivityTracerTest {
         trackableTracer.initiateRestartSpanIfNecessary(true)
         trackableTracer.endActiveSpan()
         val span = this.singleSpan
-        assertEquals("Restarted", span.name)
+        assertEquals(RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME, span.name)
+        assertEquals("Restarted", span.attributes.get(RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY))
         assertNull(span.attributes.get(RumConstants.START_TYPE_KEY))
     }
 
@@ -111,7 +113,8 @@ class ActivityTracerTest {
         trackableTracer.startActivityCreation()
         trackableTracer.endActiveSpan()
         val span = this.singleSpan
-        assertEquals("Created", span.name)
+        assertEquals(RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME, span.name)
+        assertEquals("Created", span.attributes.get(RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY))
         assertNull(span.attributes.get(RumConstants.START_TYPE_KEY))
     }
 
@@ -128,7 +131,7 @@ class ActivityTracerTest {
         trackableTracer.startActivityCreation()
         trackableTracer.endActiveSpan()
         val span = this.singleSpan
-        assertEquals("AppStart", span.name)
+        assertEquals(RumConstants.APP_START_SPAN_NAME, span.name)
         assertEquals("warm", span.attributes.get(RumConstants.START_TYPE_KEY))
     }
 
@@ -150,11 +153,12 @@ class ActivityTracerTest {
         assertEquals(2, spans.size)
 
         val appStartSpan = spans[0]
-        assertEquals("AppStart", appStartSpan.name)
+        assertEquals(RumConstants.APP_START_SPAN_NAME, appStartSpan.name)
         assertEquals("cold", appStartSpan.attributes.get(RumConstants.START_TYPE_KEY))
 
         val innerSpan = spans[1]
-        assertEquals("Created", innerSpan.name)
+        assertEquals(RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME, innerSpan.name)
+        assertEquals("Created", innerSpan.attributes.get(RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY))
     }
 
     @Test

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/Pre29ActivityLifecycleCallbacksTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/Pre29ActivityLifecycleCallbacksTest.kt
@@ -93,7 +93,7 @@ internal class Pre29ActivityLifecycleCallbacksTest {
 
         val span = spans[0]
 
-        assertEquals("AppStart", span.name)
+        assertEquals(RumConstants.APP_START_SPAN_NAME, span.name)
         assertEquals("warm", span.attributes.get(RumConstants.START_TYPE_KEY))
         assertEquals(
             activity.javaClass.simpleName,
@@ -134,7 +134,7 @@ internal class Pre29ActivityLifecycleCallbacksTest {
 
         val span = spans[0]
 
-        assertEquals("AppStart", span.name)
+        assertEquals(RumConstants.APP_START_SPAN_NAME, span.name)
         assertEquals("hot", span.attributes.get(RumConstants.START_TYPE_KEY))
         assertEquals(
             activity.javaClass.simpleName,
@@ -170,7 +170,8 @@ internal class Pre29ActivityLifecycleCallbacksTest {
 
         val span = spans[0]
 
-        assertEquals("Resumed", span.name)
+        assertEquals(RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME, span.name)
+        assertEquals("Resumed", span.attributes.get(RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY))
         assertEquals(
             activity.javaClass.simpleName,
             span.attributes.get(ActivityTracer.ACTIVITY_NAME_KEY),
@@ -205,7 +206,8 @@ internal class Pre29ActivityLifecycleCallbacksTest {
 
         val span = spans[0]
 
-        assertEquals("Destroyed", span.name)
+        assertEquals(RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME, span.name)
+        assertEquals("Destroyed", span.attributes.get(RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY))
         assertEquals(
             activity.javaClass.simpleName,
             span.attributes.get(ActivityTracer.ACTIVITY_NAME_KEY),
@@ -237,7 +239,8 @@ internal class Pre29ActivityLifecycleCallbacksTest {
 
         val stoppedSpan = spans[0]
 
-        assertEquals("Stopped", stoppedSpan.name)
+        assertEquals(RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME, stoppedSpan.name)
+        assertEquals("Stopped", stoppedSpan.attributes.get(RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY))
         assertEquals(
             activity.javaClass.simpleName,
             stoppedSpan.attributes.get(ActivityTracer.ACTIVITY_NAME_KEY),
@@ -255,7 +258,8 @@ internal class Pre29ActivityLifecycleCallbacksTest {
 
         val destroyedSpan = spans[1]
 
-        assertEquals("Destroyed", destroyedSpan.name)
+        assertEquals(RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME, destroyedSpan.name)
+        assertEquals("Destroyed", destroyedSpan.attributes.get(RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY))
         assertEquals(
             activity.javaClass.simpleName,
             destroyedSpan.attributes.get(ActivityTracer.ACTIVITY_NAME_KEY),
@@ -287,7 +291,8 @@ internal class Pre29ActivityLifecycleCallbacksTest {
 
         val stoppedSpan = spans[0]
 
-        assertEquals("Paused", stoppedSpan.name)
+        assertEquals(RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME, stoppedSpan.name)
+        assertEquals("Paused", stoppedSpan.attributes.get(RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY))
         assertEquals(
             activity.javaClass.simpleName,
             stoppedSpan.attributes.get(ActivityTracer.ACTIVITY_NAME_KEY),
@@ -305,7 +310,8 @@ internal class Pre29ActivityLifecycleCallbacksTest {
 
         val destroyedSpan = spans[1]
 
-        assertEquals("Stopped", destroyedSpan.name)
+        assertEquals(RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME, destroyedSpan.name)
+        assertEquals("Stopped", destroyedSpan.attributes.get(RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY))
         assertEquals(
             activity.javaClass.simpleName,
             destroyedSpan.attributes.get(ActivityTracer.ACTIVITY_NAME_KEY),

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimerTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimerTest.kt
@@ -40,7 +40,7 @@ internal class AppStartupTimerTest {
         assertEquals(1, spans.size)
         val spanData = spans[0]
 
-        assertEquals("AppStart", spanData.name)
+        assertEquals(RumConstants.APP_START_SPAN_NAME, spanData.name)
         assertEquals(
             "cold",
             spanData.attributes.get(RumConstants.START_TYPE_KEY),

--- a/instrumentation/fragment/README.md
+++ b/instrumentation/fragment/README.md
@@ -11,14 +11,15 @@ This instrumentation produces the following telemetry:
 ### Fragment state change
 
 * Type: Span
-* Name: {`Created` | `Restored` | `Resumed` | `Paused` | `Stopped` | `Destroyed` | `ViewDestroyed` | `Detached` |} (depends on the activity state transition)
-* Description: As the activity transitions between states, a span will be created to represent the
+* Name: `fragment.lifecycle`
+* Description: As the fragment transitions between states, a span will be created to represent the
   lifecycle of that state. Events are added for subsequent minor state changes.
 * SpanEvents: {
   `fragmentPreAttached` | `fragmentAttached` | `fragmentPreCreated` | `fragmentCreated` | `fragmentViewCreated`
   `fragmentStarted` | `fragmentResumed` | `fragmentPaused` | `fragmentStopped` |
   `fragmentViewDestroyed` | `fragmentDestroyed` | `fragmentDetached` }
 * Attributes:
+    * `fragment.lifecycle.event`: { `Created` | `Restored` | `Resumed` | `Paused` | `Stopped` | `Destroyed` | `ViewDestroyed` | `Detached` }
     * `fragment.name`:  name of fragment
     * `screen.name`:  name of screen
     * `last.screen.name`:  name of screen, when span contains the `fragmentResumed` event.

--- a/instrumentation/fragment/src/main/java/io/opentelemetry/android/instrumentation/fragment/FragmentTracer.kt
+++ b/instrumentation/fragment/src/main/java/io/opentelemetry/android/instrumentation/fragment/FragmentTracer.kt
@@ -20,24 +20,25 @@ internal class FragmentTracer(
 ) {
     private val fragmentName: String = fragment.javaClass.simpleName
 
-    fun startSpanIfNoneInProgress(action: String): FragmentTracer {
+    fun startSpanIfNoneInProgress(lifecycleEvent: String): FragmentTracer {
         if (activeSpan.spanInProgress()) {
             return this
         }
-        activeSpan.startSpan { createSpan(action) }
+        activeSpan.startSpan { createLifecycleSpan(lifecycleEvent) }
         return this
     }
 
     fun startFragmentCreation(): FragmentTracer {
-        activeSpan.startSpan { createSpan("Created") }
+        activeSpan.startSpan { createLifecycleSpan("Created") }
         return this
     }
 
-    private fun createSpan(spanName: String): Span {
+    private fun createLifecycleSpan(lifecycleEvent: String): Span {
         val span =
             tracer
-                .spanBuilder(spanName)
+                .spanBuilder(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME)
                 .setAttribute(FRAGMENT_NAME_KEY, fragmentName)
+                .setAttribute(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY, lifecycleEvent)
                 .startSpan()
         // do this after the span is started, so we can override the default screen.name set by the
         // RumAttributeAppender.

--- a/instrumentation/fragment/src/test/java/io/opentelemetry/android/instrumentation/fragment/FragmentTracerTest.kt
+++ b/instrumentation/fragment/src/test/java/io/opentelemetry/android/instrumentation/fragment/FragmentTracerTest.kt
@@ -49,7 +49,8 @@ internal class FragmentTracerTest {
         trackableTracer.startFragmentCreation()
         trackableTracer.endActiveSpan()
         val span = this.singleSpan
-        assertEquals("Created", span.name)
+        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, span.name)
+        assertEquals("Created", span.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY))
     }
 
     @Test

--- a/instrumentation/fragment/src/test/java/io/opentelemetry/android/instrumentation/fragment/RumFragmentLifecycleCallbacksTest.kt
+++ b/instrumentation/fragment/src/test/java/io/opentelemetry/android/instrumentation/fragment/RumFragmentLifecycleCallbacksTest.kt
@@ -56,7 +56,8 @@ internal class RumFragmentLifecycleCallbacksTest {
 
         val spanData = spans[0]
 
-        assertEquals("Created", spanData.name)
+        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, spanData.name)
+        assertEquals("Created", spanData.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY))
         assertEquals(
             fragment.javaClass.simpleName,
             spanData.attributes.get(FragmentTracer.FRAGMENT_NAME_KEY),
@@ -91,7 +92,8 @@ internal class RumFragmentLifecycleCallbacksTest {
 
         val spanData = spans[0]
 
-        assertEquals("Restored", spanData.name)
+        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, spanData.name)
+        assertEquals("Restored", spanData.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY))
         assertEquals(
             fragment.javaClass.simpleName,
             spanData.attributes.get(FragmentTracer.FRAGMENT_NAME_KEY),
@@ -124,7 +126,8 @@ internal class RumFragmentLifecycleCallbacksTest {
 
         val spanData = spans[0]
 
-        assertEquals("Resumed", spanData.name)
+        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, spanData.name)
+        assertEquals("Resumed", spanData.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY))
         assertEquals(
             fragment.javaClass.simpleName,
             spanData.attributes.get(FragmentTracer.FRAGMENT_NAME_KEY),
@@ -150,7 +153,8 @@ internal class RumFragmentLifecycleCallbacksTest {
 
         val spanData = spans[0]
 
-        assertEquals("Paused", spanData.name)
+        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, spanData.name)
+        assertEquals("Paused", spanData.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY))
         assertEquals(
             fragment.javaClass.simpleName,
             spanData.attributes.get(FragmentTracer.FRAGMENT_NAME_KEY),
@@ -167,7 +171,8 @@ internal class RumFragmentLifecycleCallbacksTest {
 
         val stopSpan = spans[1]
 
-        assertEquals("Stopped", stopSpan.name)
+        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, stopSpan.name)
+        assertEquals("Stopped", stopSpan.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY))
         assertEquals(
             fragment.javaClass.simpleName,
             stopSpan.attributes.get(FragmentTracer.FRAGMENT_NAME_KEY),
@@ -197,7 +202,8 @@ internal class RumFragmentLifecycleCallbacksTest {
         val pauseSpan = spans[0]
         val stopSpan = spans[1]
 
-        assertEquals("Paused", pauseSpan.name)
+        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, pauseSpan.name)
+        assertEquals("Paused", pauseSpan.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY))
         assertEquals(
             fragment.javaClass.simpleName,
             pauseSpan.attributes.get(FragmentTracer.FRAGMENT_NAME_KEY),
@@ -212,7 +218,8 @@ internal class RumFragmentLifecycleCallbacksTest {
         assertEquals(1, events.size)
         checkEventExists(events, "fragmentPaused")
 
-        assertEquals("Stopped", stopSpan.name)
+        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, stopSpan.name)
+        assertEquals("Stopped", stopSpan.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY))
         assertEquals(
             fragment.javaClass.simpleName,
             stopSpan.attributes.get(FragmentTracer.FRAGMENT_NAME_KEY),
@@ -229,7 +236,11 @@ internal class RumFragmentLifecycleCallbacksTest {
 
         val destroyViewSpan = spans[2]
 
-        assertEquals("ViewDestroyed", destroyViewSpan.name)
+        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, destroyViewSpan.name)
+        assertEquals(
+            "ViewDestroyed",
+            destroyViewSpan.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY),
+        )
         assertEquals(
             fragment.javaClass.simpleName,
             destroyViewSpan.attributes.get(FragmentTracer.FRAGMENT_NAME_KEY),
@@ -246,7 +257,8 @@ internal class RumFragmentLifecycleCallbacksTest {
 
         val detachSpan = spans[3]
 
-        assertEquals("Destroyed", detachSpan.name)
+        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, detachSpan.name)
+        assertEquals("Destroyed", detachSpan.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY))
         Assertions.assertNotNull(
             detachSpan.attributes.get(FragmentTracer.FRAGMENT_NAME_KEY),
         )
@@ -270,7 +282,8 @@ internal class RumFragmentLifecycleCallbacksTest {
 
         val span = spans[0]
 
-        assertEquals("ViewDestroyed", span.name)
+        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, span.name)
+        assertEquals("ViewDestroyed", span.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY))
         assertEquals(
             fragment.javaClass.simpleName,
             span.attributes.get(RumConstants.SCREEN_NAME_KEY),
@@ -298,7 +311,11 @@ internal class RumFragmentLifecycleCallbacksTest {
 
         val destroyViewSpan = spans[0]
 
-        assertEquals("ViewDestroyed", destroyViewSpan.name)
+        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, destroyViewSpan.name)
+        assertEquals(
+            "ViewDestroyed",
+            destroyViewSpan.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY),
+        )
         assertEquals(
             fragment.javaClass.simpleName,
             destroyViewSpan.attributes.get(RumConstants.SCREEN_NAME_KEY),
@@ -315,7 +332,8 @@ internal class RumFragmentLifecycleCallbacksTest {
 
         val detachSpan = spans[1]
 
-        assertEquals("Destroyed", detachSpan.name)
+        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, detachSpan.name)
+        assertEquals("Destroyed", detachSpan.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY))
         assertEquals(
             fragment.javaClass.simpleName,
             detachSpan.attributes.get(FragmentTracer.FRAGMENT_NAME_KEY),
@@ -340,7 +358,8 @@ internal class RumFragmentLifecycleCallbacksTest {
 
         val detachSpan = spans[0]
 
-        assertEquals("Detached", detachSpan.name)
+        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, detachSpan.name)
+        assertEquals("Detached", detachSpan.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY))
         assertEquals(
             fragment.javaClass.simpleName,
             detachSpan.attributes.get(RumConstants.SCREEN_NAME_KEY),

--- a/instrumentation/fragment/src/test/java/io/opentelemetry/android/instrumentation/fragment/RumFragmentLifecycleCallbacksTest.kt
+++ b/instrumentation/fragment/src/test/java/io/opentelemetry/android/instrumentation/fragment/RumFragmentLifecycleCallbacksTest.kt
@@ -16,6 +16,7 @@ import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTra
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
 import io.opentelemetry.sdk.trace.data.EventData
+import io.opentelemetry.sdk.trace.data.SpanData
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -190,84 +191,29 @@ internal class RumFragmentLifecycleCallbacksTest {
 
     @Test
     fun fragmentDetachedFromActive() {
-        val testHarness = fragmentCallbackTestHarness
-
         val fragment = mockk<Fragment>()
-        testHarness.runFragmentDetachedFromActiveLifecycle(fragment)
+        fragmentCallbackTestHarness.runFragmentDetachedFromActiveLifecycle(fragment)
 
         val spans = otelTesting.spans
-
         assertEquals(4, spans.size)
 
-        val pauseSpan = spans[0]
-        val stopSpan = spans[1]
+        assertFragmentLifecycleSpan(spans[0], "Paused", fragment)
+        assertFragmentLifecycleSpanEvents(spans[0], 1, "fragmentPaused")
 
-        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, pauseSpan.name)
-        assertEquals("Paused", pauseSpan.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY))
-        assertEquals(
-            fragment.javaClass.simpleName,
-            pauseSpan.attributes.get(FragmentTracer.FRAGMENT_NAME_KEY),
+        assertFragmentLifecycleSpan(spans[1], "Stopped", fragment)
+        assertFragmentLifecycleSpanEvents(spans[1], 1, "fragmentStopped")
+
+        assertFragmentLifecycleSpan(spans[2], "ViewDestroyed", fragment)
+        assertFragmentLifecycleSpanEvents(spans[2], 1, "fragmentViewDestroyed")
+
+        assertFragmentLifecycleSpan(
+            spans[3],
+            "Destroyed",
+            fragment,
+            requireFragmentNameValue = false,
+            requireScreenName = false,
         )
-        assertEquals(
-            fragment.javaClass.simpleName,
-            pauseSpan.attributes.get(RumConstants.SCREEN_NAME_KEY),
-        )
-        assertNull(pauseSpan.attributes.get(RumConstants.LAST_SCREEN_NAME_KEY))
-
-        var events: List<EventData> = pauseSpan.events
-        assertEquals(1, events.size)
-        checkEventExists(events, "fragmentPaused")
-
-        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, stopSpan.name)
-        assertEquals("Stopped", stopSpan.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY))
-        assertEquals(
-            fragment.javaClass.simpleName,
-            stopSpan.attributes.get(FragmentTracer.FRAGMENT_NAME_KEY),
-        )
-        assertEquals(
-            fragment.javaClass.simpleName,
-            stopSpan.attributes.get(RumConstants.SCREEN_NAME_KEY),
-        )
-        assertNull(stopSpan.attributes.get(RumConstants.LAST_SCREEN_NAME_KEY))
-
-        val stopEvents = stopSpan.events
-        assertEquals(1, stopEvents.size)
-        checkEventExists(stopEvents, "fragmentStopped")
-
-        val destroyViewSpan = spans[2]
-
-        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, destroyViewSpan.name)
-        assertEquals(
-            "ViewDestroyed",
-            destroyViewSpan.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY),
-        )
-        assertEquals(
-            fragment.javaClass.simpleName,
-            destroyViewSpan.attributes.get(FragmentTracer.FRAGMENT_NAME_KEY),
-        )
-        assertEquals(
-            fragment.javaClass.simpleName,
-            destroyViewSpan.attributes.get(RumConstants.SCREEN_NAME_KEY),
-        )
-        assertNull(destroyViewSpan.attributes.get(RumConstants.LAST_SCREEN_NAME_KEY))
-
-        events = destroyViewSpan.events
-        assertEquals(1, events.size)
-        checkEventExists(events, "fragmentViewDestroyed")
-
-        val detachSpan = spans[3]
-
-        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, detachSpan.name)
-        assertEquals("Destroyed", detachSpan.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY))
-        Assertions.assertNotNull(
-            detachSpan.attributes.get(FragmentTracer.FRAGMENT_NAME_KEY),
-        )
-        assertNull(detachSpan.attributes.get(RumConstants.LAST_SCREEN_NAME_KEY))
-
-        events = detachSpan.events
-        assertEquals(2, events.size)
-        checkEventExists(events, "fragmentDestroyed")
-        checkEventExists(events, "fragmentDetached")
+        assertFragmentLifecycleSpanEvents(spans[3], 2, "fragmentDestroyed", "fragmentDetached")
     }
 
     @Test
@@ -373,6 +319,42 @@ internal class RumFragmentLifecycleCallbacksTest {
         val events = detachSpan.events
         assertEquals(1, events.size)
         checkEventExists(events, "fragmentDetached")
+    }
+
+    private fun assertFragmentLifecycleSpan(
+        span: SpanData,
+        lifecycleEvent: String,
+        fragment: Fragment,
+        requireFragmentNameValue: Boolean = true,
+        requireScreenName: Boolean = true,
+    ) {
+        assertEquals(RumConstants.FRAGMENT_LIFECYCLE_SPAN_NAME, span.name)
+        assertEquals(lifecycleEvent, span.attributes.get(RumConstants.FRAGMENT_LIFECYCLE_EVENT_KEY))
+        if (requireFragmentNameValue) {
+            assertEquals(
+                fragment.javaClass.simpleName,
+                span.attributes.get(FragmentTracer.FRAGMENT_NAME_KEY),
+            )
+        } else {
+            Assertions.assertNotNull(span.attributes.get(FragmentTracer.FRAGMENT_NAME_KEY))
+        }
+        if (requireScreenName) {
+            assertEquals(
+                fragment.javaClass.simpleName,
+                span.attributes.get(RumConstants.SCREEN_NAME_KEY),
+            )
+        }
+        assertNull(span.attributes.get(RumConstants.LAST_SCREEN_NAME_KEY))
+    }
+
+    private fun assertFragmentLifecycleSpanEvents(
+        span: SpanData,
+        expectedEventCount: Int,
+        vararg eventNames: String,
+    ) {
+        val events = span.events
+        assertEquals(expectedEventCount, events.size)
+        eventNames.forEach { checkEventExists(events, it) }
     }
 
     private fun checkEventExists(


### PR DESCRIPTION
## Summary

- Rename startup span `AppStart` → `app.start` (`RumConstants.APP_START_SPAN_NAME`)
- Unify activity lifecycle spans under `activity.lifecycle` with `activity.lifecycle.event` (`Created`, `Resumed`, `Paused`, `Stopped`, `Destroyed`, `Restarted`)
- Unify fragment lifecycle spans under `fragment.lifecycle` with `fragment.lifecycle.event` (`Created`, `Restored`, `Resumed`, `Paused`, `Stopped`, `Destroyed`, `ViewDestroyed`, `Detached`)
- Span events (`activityPreCreated`, `fragmentResumed`, etc.) are unchanged
- Cold start still parents `activity.lifecycle` (event `Created`) under `app.start`

## Breaking change

Consumers querying `span.name = "Resumed"` or `span.name = "AppStart"` must migrate to:
- `span.name = "app.start"`
- `span.name = "activity.lifecycle"` with `activity.lifecycle.event = "Resumed"` (and equivalent for fragment)

## Test plan

- [x] `./gradlew :common:apiDump` (run separately from `apiCheck`)
- [x] `./gradlew :common:apiCheck spotlessApply :instrumentation:activity:test :instrumentation:fragment:test`
- [ ] Verify trace tree in demo/backend after consuming updated artifacts