### PR TITLE
feat(instrumentation): add system-metrics instrumentation

### DIFF
--- a/instrumentation/system-metrics/api/system-metrics.api
+++ b/instrumentation/system-metrics/api/system-metrics.api
@@ -1,0 +1,10 @@
+public final class io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public fun <init> ()V
+	public final fun getCollectionInterval ()Ljava/time/Duration;
+	public final fun getEmitAsSpans ()Z
+	public fun getName ()Ljava/lang/String;
+	public fun install (Landroid/content/Context;Lio/opentelemetry/android/OpenTelemetryRum;)V
+	public final fun setCollectionInterval (Ljava/time/Duration;)V
+	public final fun setEmitAsSpans (Z)V
+}
+

--- a/instrumentation/system-metrics/build.gradle.kts
+++ b/instrumentation/system-metrics/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    id("otel.android-library-conventions")
+    id("otel.publish-conventions")
+}
+
+description = "OpenTelemetry Android system metrics instrumentation"
+
+android {
+    namespace = "io.opentelemetry.android.instrumentation.systemmetrics"
+
+    defaultConfig {
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
+}
+
+dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
+    implementation(project(":instrumentation:android-instrumentation"))
+    implementation(project(":common"))
+    implementation(libs.opentelemetry.sdk)
+    testImplementation(libs.robolectric)
+}

--- a/instrumentation/system-metrics/src/main/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/ActiveSpanRegistry.kt
+++ b/instrumentation/system-metrics/src/main/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/ActiveSpanRegistry.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.systemmetrics
+
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.trace.ReadWriteSpan
+import io.opentelemetry.sdk.trace.ReadableSpan
+import io.opentelemetry.sdk.trace.SpanProcessor
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * A [SpanProcessor] that tracks the most recently started span across all threads.
+ *
+ * Used by [SystemMetricsSpanEmitter] to decide at each collection tick whether to:
+ * - Attach an `"app.metrics"` event to the currently active span, OR
+ * - Emit a standalone `"app.metrics"` span when no user span is in flight.
+ *
+ * Thread safety: [AtomicReference] guarantees visibility across the UI thread (span
+ * creation) and the background [java.util.concurrent.ScheduledExecutorService] thread
+ * (metrics emission) without locking.
+ */
+internal class ActiveSpanRegistry : SpanProcessor {
+    private val mostRecentRef = AtomicReference<ReadWriteSpan?>(null)
+
+    /**
+     * Returns the most recently started span if it has not yet ended, or null otherwise.
+     *
+     * Safe to call from any thread. If the span ended between the registry check and the
+     * subsequent [ReadWriteSpan.addEvent] call, the OTel SDK silently discards the event
+     * on an ended span — no crash, no data corruption.
+     */
+    fun mostRecentActiveSpan(): ReadWriteSpan? = mostRecentRef.get()?.takeIf { !it.hasEnded() }
+
+    override fun onStart(
+        parentContext: Context,
+        span: ReadWriteSpan,
+    ) {
+        mostRecentRef.set(span)
+    }
+
+    override fun isStartRequired(): Boolean = true
+
+    override fun onEnd(span: ReadableSpan) {
+        // Only null out the ref if this is the same span we are tracking.
+        // CAS prevents a race where a new span starts between the get() and compareAndSet().
+        val current = mostRecentRef.get() ?: return
+        if (current.spanContext == span.spanContext) {
+            mostRecentRef.compareAndSet(current, null)
+        }
+    }
+
+    override fun isEndRequired(): Boolean = true
+}

--- a/instrumentation/system-metrics/src/main/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsInstrumentation.kt
+++ b/instrumentation/system-metrics/src/main/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsInstrumentation.kt
@@ -1,0 +1,244 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.systemmetrics
+
+import android.content.Context
+import com.google.auto.service.AutoService
+import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.instrumentation.AndroidInstrumentation
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.metrics.Meter
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.trace.SpanProcessor
+import java.time.Duration
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Entry point for system metrics instrumentation.
+ *
+ * Registers observable gauges for CPU, memory, and thread metrics using the
+ * OpenTelemetry [io.opentelemetry.sdk.metrics.SdkMeterProvider] already configured
+ * in the SDK. Metrics are collected at the configured [collectionInterval] by the
+ * SDK's [io.opentelemetry.sdk.metrics.export.PeriodicMetricReader].
+ */
+@AutoService(AndroidInstrumentation::class)
+class SystemMetricsInstrumentation : AndroidInstrumentation {
+    /** Interval at which all system metrics are sampled. Default: 30 seconds. */
+    var collectionInterval: Duration = Duration.ofSeconds(30)
+
+    /**
+     * When true, emits a `process.system.metrics` span every [collectionInterval] with all
+     * metric values as span attributes. Useful for trace-only backends (Jaeger, Zipkin) or
+     * when metric snapshots need to be stitched into a trace.
+     * Default: false (metrics-only via ObservableGauge).
+     */
+    var emitAsSpans: Boolean = false
+
+    override val name: String = "system-metrics"
+
+    private val installed = AtomicBoolean(false)
+
+    override fun install(
+        context: Context,
+        openTelemetryRum: OpenTelemetryRum,
+    ) {
+        if (!installed.compareAndSet(false, true)) return
+
+        val meter =
+            openTelemetryRum.openTelemetry
+                .meterProvider
+                .get("io.opentelemetry.android.system-metrics")
+
+        val cpuReader = CpuMetricsReader()
+        val memoryReader = MemoryMetricsReader()
+        val threadReader = ThreadMetricsReader()
+        val deviceReader = DeviceMetricsReader(context)
+
+        registerProcessMetrics(meter, cpuReader, memoryReader, threadReader)
+        registerDeviceMetrics(meter, deviceReader)
+
+        if (emitAsSpans) {
+            val registry = ActiveSpanRegistry()
+            // Inject the registry as a SpanProcessor into the already-built SdkTracerProvider
+            // so it receives onStart/onEnd callbacks for every span created in the app.
+            val sdk = openTelemetryRum.openTelemetry as? OpenTelemetrySdk
+            sdk?.let { injectSpanProcessor(it, registry) }
+            SystemMetricsSpanEmitter(
+                openTelemetry = openTelemetryRum.openTelemetry,
+                scheduler = Executors.newSingleThreadScheduledExecutor(),
+                intervalSeconds = collectionInterval.seconds,
+                activeSpanRegistry = registry,
+                deviceReader = deviceReader,
+            ).start()
+        }
+    }
+
+    private fun registerProcessMetrics(
+        meter: Meter,
+        cpuReader: CpuMetricsReader,
+        memoryReader: MemoryMetricsReader,
+        threadReader: ThreadMetricsReader,
+    ) {
+        meter
+            .gaugeBuilder("process.cpu.usage")
+            .setDescription("CPU usage of this process as a percentage (0–100)")
+            .setUnit("%")
+            .buildWithCallback { measurement ->
+                measurement.record(cpuReader.readCpuUsagePercent())
+            }
+
+        meter
+            .gaugeBuilder("process.runtime.jvm.memory.heap.used")
+            .setDescription("Java heap memory currently used by this process")
+            .setUnit("By")
+            .ofLongs()
+            .buildWithCallback { measurement ->
+                measurement.record(memoryReader.readHeapUsedBytes())
+            }
+
+        meter
+            .gaugeBuilder("process.runtime.jvm.memory.native.used")
+            .setDescription("Native heap memory currently allocated by this process")
+            .setUnit("By")
+            .ofLongs()
+            .buildWithCallback { measurement ->
+                measurement.record(memoryReader.readNativeHeapUsedBytes())
+            }
+
+        meter
+            .gaugeBuilder("process.memory.pss")
+            .setDescription("Proportional Set Size memory for this process")
+            .setUnit("kBy")
+            .ofLongs()
+            .buildWithCallback { measurement ->
+                measurement.record(memoryReader.readPssKb())
+            }
+
+        meter
+            .gaugeBuilder("process.thread.count")
+            .setDescription("Total number of threads currently active in this process")
+            .setUnit("{thread}")
+            .ofLongs()
+            .buildWithCallback { measurement ->
+                measurement.record(threadReader.readThreadCount())
+            }
+
+        meter
+            .gaugeBuilder("process.thread.count.by_state")
+            .setDescription("Thread count grouped by thread state")
+            .setUnit("{thread}")
+            .ofLongs()
+            .buildWithCallback { measurement ->
+                threadReader.readThreadCountByState().forEach { (state, count) ->
+                    measurement.record(
+                        count,
+                        Attributes.of(
+                            AttributeKey.stringKey("thread.state"),
+                            state,
+                        ),
+                    )
+                }
+            }
+    }
+
+    private fun registerDeviceMetrics(
+        meter: Meter,
+        deviceReader: DeviceMetricsReader,
+    ) {
+        meter
+            .gaugeBuilder("system.memory.available")
+            .setDescription("Available (free) RAM on the device")
+            .setUnit("By")
+            .ofLongs()
+            .buildWithCallback { measurement ->
+                measurement.record(deviceReader.readAvailableRamBytes())
+            }
+
+        meter
+            .gaugeBuilder("system.memory.total")
+            .setDescription("Total physical RAM on the device")
+            .setUnit("By")
+            .ofLongs()
+            .buildWithCallback { measurement ->
+                measurement.record(deviceReader.readTotalRamBytes())
+            }
+
+        meter
+            .gaugeBuilder("system.memory.low")
+            .setDescription("1 if the device is in a low-memory state, 0 otherwise")
+            .setUnit("1")
+            .ofLongs()
+            .buildWithCallback { measurement ->
+                measurement.record(deviceReader.readLowMemoryFlag())
+            }
+
+        meter
+            .gaugeBuilder("system.battery.level")
+            .setDescription("Battery charge level as a percentage (0–100)")
+            .setUnit("%")
+            .buildWithCallback { measurement ->
+                measurement.record(deviceReader.readBatteryPercent())
+            }
+
+        meter
+            .gaugeBuilder("system.battery.temperature")
+            .setDescription("Battery temperature in degrees Celsius")
+            .setUnit("Cel")
+            .buildWithCallback { measurement ->
+                measurement.record(deviceReader.readBatteryTemperatureCelsius())
+            }
+
+        meter
+            .gaugeBuilder("system.disk.free")
+            .setDescription("Free disk space on the internal data partition")
+            .setUnit("By")
+            .ofLongs()
+            .buildWithCallback { measurement ->
+                measurement.record(deviceReader.readDiskFreeBytes())
+            }
+
+        meter
+            .gaugeBuilder("system.disk.total")
+            .setDescription("Total disk space on the internal data partition")
+            .setUnit("By")
+            .ofLongs()
+            .buildWithCallback { measurement ->
+                measurement.record(deviceReader.readDiskTotalBytes())
+            }
+    }
+
+    /**
+     * Injects [processor] into the already-built [OpenTelemetrySdk]'s TracerProvider using
+     * reflection. This is necessary because [AndroidInstrumentation.install] is called after
+     * the SDK is fully constructed, so the standard builder API is no longer available.
+     *
+     * Reflection targets are both package-private JVM classes in the OTel SDK — not Android
+     * platform internals — so this works across all supported Android API levels.
+     * A failure here degrades gracefully: span events fall back to standalone spans.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun injectSpanProcessor(
+        sdk: OpenTelemetrySdk,
+        processor: SpanProcessor,
+    ) {
+        try {
+            val sharedStateField =
+                sdk.sdkTracerProvider.javaClass.getDeclaredField("sharedState")
+            sharedStateField.isAccessible = true
+            val sharedState = sharedStateField.get(sdk.sdkTracerProvider)
+
+            val processorField = sharedState.javaClass.getDeclaredField("activeSpanProcessor")
+            processorField.isAccessible = true
+            val existing = processorField.get(sharedState) as SpanProcessor
+
+            processorField.set(sharedState, SpanProcessor.composite(existing, processor))
+        } catch (e: Exception) {
+            // Graceful degradation: metrics will emit as standalone spans instead of events.
+        }
+    }
+}

--- a/instrumentation/system-metrics/src/main/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsReaders.kt
+++ b/instrumentation/system-metrics/src/main/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsReaders.kt
@@ -1,0 +1,203 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.systemmetrics
+
+import android.app.ActivityManager
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import android.os.Debug
+import android.os.Environment
+import android.os.Process
+import android.os.StatFs
+import android.os.SystemClock
+
+/**
+ * Reads memory-related metrics for the current process.
+ *
+ * - Heap used: Java heap bytes currently in use.
+ * - Native heap: Native allocations tracked by [Debug].
+ * - PSS: Proportional Set Size read from [Debug.MemoryInfo] (shared memory counted proportionally).
+ */
+internal class MemoryMetricsReader {
+    /** Java heap bytes currently used (total - free). */
+    fun readHeapUsedBytes(): Long {
+        val rt = Runtime.getRuntime()
+        return rt.totalMemory() - rt.freeMemory()
+    }
+
+    /** Java heap bytes committed (allocated) from the OS — includes used + free portions. */
+    fun readHeapAllocatedBytes(): Long = Runtime.getRuntime().totalMemory()
+
+    /** Java heap bytes currently free (committed but not in use). */
+    fun readHeapFreeBytes(): Long = Runtime.getRuntime().freeMemory()
+
+    /** Native heap bytes allocated via malloc/JNI. */
+    fun readNativeHeapUsedBytes(): Long = Debug.getNativeHeapAllocatedSize()
+
+    /**
+     * Proportional Set Size in kB.
+     * [Debug.getMemoryInfo] is a blocking binder call — only run this at a longer
+     * interval (≥ 30 s) to avoid overhead.
+     */
+    fun readPssKb(): Long {
+        val mi = Debug.MemoryInfo()
+        Debug.getMemoryInfo(mi)
+        return mi.totalPss.toLong()
+    }
+}
+
+/**
+ * Reads CPU usage for the current process using Android OS APIs (works on Android 10+).
+ *
+ * Uses [Process.getElapsedCpuTime] which is thread-safe and doesn't require /proc filesystem access
+ * (which is restricted on modern Android). Calculates CPU % as the delta since last call.
+ */
+internal class CpuMetricsReader {
+    private var lastCpuTimeMs = 0L
+    private var lastWallTimeMs = 0L
+
+    /**
+     * Returns CPU usage percentage (0–100) since the last call.
+     * Thread-safe and works on all Android versions including API 29+.
+     *
+     * Formula:
+     *   CPU % = (CPU time delta / Wall time delta) × 100
+     */
+    fun readCpuUsagePercent(): Double {
+        val nowCpuMs = Process.getElapsedCpuTime()
+        val nowWallMs = SystemClock.elapsedRealtime()
+
+        val deltaCpuMs = nowCpuMs - lastCpuTimeMs
+        val deltaWallMs = nowWallMs - lastWallTimeMs
+
+        lastCpuTimeMs = nowCpuMs
+        lastWallTimeMs = nowWallMs
+
+        if (deltaWallMs <= 0) return 0.0
+
+        return (deltaCpuMs.toDouble() / deltaWallMs) * 100.0
+    }
+}
+
+/**
+ * Reads device-level (system-wide) metrics.
+ *
+ * These reflect the state of the whole device, not just this app's process.
+ */
+internal open class DeviceMetricsReader(private val context: Context) {
+    private val activityManager: ActivityManager by lazy {
+        context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+    }
+
+    /** Total physical RAM on the device in bytes. */
+    open fun readTotalRamBytes(): Long {
+        val info = ActivityManager.MemoryInfo()
+        activityManager.getMemoryInfo(info)
+        return info.totalMem
+    }
+
+    /** Available (free) RAM on the device in bytes. */
+    open fun readAvailableRamBytes(): Long {
+        val info = ActivityManager.MemoryInfo()
+        activityManager.getMemoryInfo(info)
+        return info.availMem
+    }
+
+    /** 1 if the device is in a low-memory state, 0 otherwise. */
+    open fun readLowMemoryFlag(): Long {
+        val info = ActivityManager.MemoryInfo()
+        activityManager.getMemoryInfo(info)
+        return if (info.lowMemory) 1L else 0L
+    }
+
+    /** Battery level as a percentage (0–100). Returns -1 if unavailable. */
+    open fun readBatteryPercent(): Double {
+        val intent =
+            context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+                ?: return -1.0
+        val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+        val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+        if (level < 0 || scale <= 0) return -1.0
+        return (level.toDouble() / scale) * 100.0
+    }
+
+    /** Battery temperature in degrees Celsius. Returns -1 if unavailable. */
+    open fun readBatteryTemperatureCelsius(): Double {
+        val intent =
+            context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+                ?: return -1.0
+        val tenthsDegrees = intent.getIntExtra(BatteryManager.EXTRA_TEMPERATURE, -1)
+        if (tenthsDegrees < 0) return -1.0
+        return tenthsDegrees / 10.0
+    }
+
+    /**
+     * Free disk space on the internal data partition in bytes.
+     */
+    open fun readDiskFreeBytes(): Long {
+        return try {
+            val stat = StatFs(Environment.getDataDirectory().path)
+            val blockSize = stat.blockSizeLong
+            if (blockSize <= 0) return -1L
+            stat.availableBlocksLong * blockSize
+        } catch (_: Exception) {
+            -1L
+        }
+    }
+
+    /** Total disk space on the internal data partition in bytes. */
+    open fun readDiskTotalBytes(): Long {
+        return try {
+            val stat = StatFs(Environment.getDataDirectory().path)
+            val blockSize = stat.blockSizeLong
+            if (blockSize <= 0) return -1L
+            stat.blockCountLong * blockSize
+        } catch (_: Exception) {
+            -1L
+        }
+    }
+}
+
+/**
+ * Reads thread-related metrics for the current process.
+ *
+ * Uses lightweight APIs:
+ * - [Thread.activeCount] for regular thread count (fast)
+ * - Reserves [Thread.getAllStackTraces] only for error diagnosis (expensive)
+ */
+internal class ThreadMetricsReader {
+    /**
+     * Total number of live threads in this JVM process.
+     *
+     * Uses [ThreadGroup.activeCount] which is thread-safe and lightweight.
+     * Much faster than [Thread.getAllStackTraces] which triggers a full thread dump.
+     */
+    fun readThreadCount(): Long {
+        return try {
+            Thread.currentThread().threadGroup?.activeCount()?.toLong() ?: 0L
+        } catch (_: Exception) {
+            0L
+        }
+    }
+
+    /**
+     * Returns a map of [Thread.State] name → count for all currently live threads.
+     *
+     * **WARNING:** This method triggers a full JVM thread dump, pausing all threads.
+     * Only call this as a fallback for error diagnosis, not in normal metric collection.
+     *
+     * Use case: When an ANR is detected or thread count exceeds critical threshold (>80 threads).
+     */
+    fun readThreadCountByState(): Map<String, Long> =
+        Thread
+            .getAllStackTraces()
+            .keys
+            .groupingBy { it.state.name }
+            .eachCount()
+            .mapValues { it.value.toLong() }
+}

--- a/instrumentation/system-metrics/src/main/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsSpanEmitter.kt
+++ b/instrumentation/system-metrics/src/main/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsSpanEmitter.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.systemmetrics
+
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.SpanKind
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+/**
+ * Periodically captures a snapshot of all system + device metrics and delivers it via
+ * one of two paths depending on whether a user span is currently in flight:
+ *
+ * **Path A — Event on active span (preferred):**
+ * When [ActiveSpanRegistry] reports a live span, the metrics snapshot is attached as a
+ * named event `"app.metrics"` directly on that span.
+ *
+ * **Path B — Standalone span (fallback):**
+ * When no user span is active, a dedicated instant span named `"app.metrics"` is emitted.
+ *
+ * **CPU min/max tracking:**
+ * A 1-second sub-sampler feeds a rolling window for CPU usage. Each emission includes
+ * the min and max CPU observed since the last emission.
+ *
+ * **Device metrics caching:**
+ * Expensive device metrics (PSS, battery, disk, RAM) are refreshed every 60 seconds on
+ * a background cache timer to keep emit latency under 1ms.
+ */
+internal class SystemMetricsSpanEmitter(
+    private val openTelemetry: OpenTelemetry,
+    private val scheduler: ScheduledExecutorService,
+    private val intervalSeconds: Long,
+    private val activeSpanRegistry: ActiveSpanRegistry,
+    private val cpuReader: CpuMetricsReader = CpuMetricsReader(),
+    private val memoryReader: MemoryMetricsReader = MemoryMetricsReader(),
+    private val threadReader: ThreadMetricsReader = ThreadMetricsReader(),
+    private val deviceReader: DeviceMetricsReader,
+) {
+
+    private val tracer =
+        openTelemetry.tracerProvider.get("io.opentelemetry.android.system-metrics")
+
+    // Device metrics cache — refreshed every 60 s by the cache timer.
+    @Volatile private var cachedPssKb = 0L
+    @Volatile private var cachedTotalRamBytes = 0L
+    @Volatile private var cachedAvailableRamBytes = 0L
+    @Volatile private var cachedLowMemoryFlag = 0L
+    @Volatile private var cachedBatteryPercent = 0.0
+    @Volatile private var cachedBatteryTempCelsius = 0.0
+    @Volatile private var cachedDiskFreeBytes = 0L
+    @Volatile private var cachedDiskTotalBytes = 0L
+
+    // CPU sub-sampling window — accessed exclusively from the single scheduler thread.
+    private var lastCpuSample = 0.0
+    private var cpuMin = Double.MAX_VALUE
+    private var cpuMax = 0.0
+
+    fun start() {
+        // Seed baseline so first CPU delta has a valid reference.
+        cpuReader.readCpuUsagePercent()
+
+        // 1-second sub-sampler — populates the CPU min/max window between emissions.
+        @Suppress("DiscouragedApi")
+        scheduler.scheduleAtFixedRate(::sampleCpu, 1L, 1L, TimeUnit.SECONDS)
+
+        // Main emit timer: attach-or-standalone every intervalSeconds.
+        @Suppress("DiscouragedApi")
+        scheduler.scheduleAtFixedRate(::emitMetrics, intervalSeconds, intervalSeconds, TimeUnit.SECONDS)
+
+        // Cache refresh timer: expensive binder calls every 60 seconds.
+        @Suppress("DiscouragedApi")
+        scheduler.scheduleAtFixedRate(::refreshDeviceCache, 60L, 60L, TimeUnit.SECONDS)
+    }
+
+    /** Runs every 1 second to track CPU min/max between emissions. */
+    private fun sampleCpu() {
+        val cpu = cpuReader.readCpuUsagePercent()
+        lastCpuSample = cpu
+        if (cpu < cpuMin) cpuMin = cpu
+        if (cpu > cpuMax) cpuMax = cpu
+    }
+
+    private fun resetCpuWindow() {
+        cpuMin = Double.MAX_VALUE
+        cpuMax = 0.0
+    }
+
+    private fun emitMetrics() {
+        val sample =
+            ProcessSample(
+                cpuUsage = lastCpuSample,
+                cpuMin = cpuMin.takeIf { it != Double.MAX_VALUE } ?: 0.0,
+                cpuMax = cpuMax,
+                heapUsed = memoryReader.readHeapUsedBytes(),
+                heapAllocated = memoryReader.readHeapAllocatedBytes(),
+                heapFree = memoryReader.readHeapFreeBytes(),
+                nativeUsed = memoryReader.readNativeHeapUsedBytes(),
+                threadCount = threadReader.readThreadCount(),
+            )
+        resetCpuWindow()
+
+        val activeSpan = activeSpanRegistry.mostRecentActiveSpan()
+        if (activeSpan != null) {
+            activeSpan.addEvent("app.metrics", buildAttributes(sample))
+        } else {
+            emitStandaloneSpan(sample)
+        }
+    }
+
+    private fun emitStandaloneSpan(sample: ProcessSample) {
+        val span =
+            tracer
+                .spanBuilder("app.metrics")
+                .setSpanKind(SpanKind.INTERNAL)
+                .startSpan()
+        try {
+            span.addEvent("app.metrics", buildAttributes(sample))
+        } finally {
+            span.end()
+        }
+    }
+
+    private fun buildAttributes(sample: ProcessSample): Attributes =
+        Attributes
+            .builder()
+            .put(ATTR_CPU_USAGE, sample.cpuUsage)
+            .put(ATTR_CPU_MIN, sample.cpuMin)
+            .put(ATTR_CPU_MAX, sample.cpuMax)
+            .put(ATTR_HEAP_USED, sample.heapUsed)
+            .put(ATTR_HEAP_ALLOCATED, sample.heapAllocated)
+            .put(ATTR_HEAP_FREE, sample.heapFree)
+            .put(ATTR_NATIVE_USED, sample.nativeUsed)
+            .put(ATTR_THREAD_COUNT, sample.threadCount)
+            .put(ATTR_PSS_KB, cachedPssKb)
+            .put(ATTR_SYS_MEM_TOTAL, cachedTotalRamBytes)
+            .put(ATTR_SYS_MEM_AVAILABLE, cachedAvailableRamBytes)
+            .put(ATTR_SYS_MEM_LOW, cachedLowMemoryFlag)
+            .put(ATTR_BATTERY_LEVEL, cachedBatteryPercent)
+            .put(ATTR_BATTERY_TEMP, cachedBatteryTempCelsius)
+            .put(ATTR_DISK_FREE, cachedDiskFreeBytes)
+            .put(ATTR_DISK_TOTAL, cachedDiskTotalBytes)
+            .build()
+
+    private fun refreshDeviceCache() {
+        try {
+            cachedPssKb = memoryReader.readPssKb()
+            cachedTotalRamBytes = deviceReader.readTotalRamBytes()
+            cachedAvailableRamBytes = deviceReader.readAvailableRamBytes()
+            cachedLowMemoryFlag = deviceReader.readLowMemoryFlag()
+            cachedBatteryPercent = deviceReader.readBatteryPercent()
+            cachedBatteryTempCelsius = deviceReader.readBatteryTemperatureCelsius()
+            cachedDiskFreeBytes = deviceReader.readDiskFreeBytes()
+            cachedDiskTotalBytes = deviceReader.readDiskTotalBytes()
+        } catch (_: Exception) {
+            // Silent fail — stale cache values are used until next refresh
+        }
+    }
+
+    private data class ProcessSample(
+        val cpuUsage: Double,
+        val cpuMin: Double,
+        val cpuMax: Double,
+        val heapUsed: Long,
+        val heapAllocated: Long,
+        val heapFree: Long,
+        val nativeUsed: Long,
+        val threadCount: Long,
+    )
+
+    companion object {
+        // Process — CPU
+        val ATTR_CPU_USAGE: AttributeKey<Double> = AttributeKey.doubleKey("process.cpu.usage")
+        val ATTR_CPU_MIN: AttributeKey<Double> = AttributeKey.doubleKey("process.cpu.usage.min")
+        val ATTR_CPU_MAX: AttributeKey<Double> = AttributeKey.doubleKey("process.cpu.usage.max")
+
+        // Process — heap (current values only)
+        val ATTR_HEAP_USED: AttributeKey<Long> = AttributeKey.longKey("process.memory.heap.used")
+        val ATTR_HEAP_ALLOCATED: AttributeKey<Long> = AttributeKey.longKey("process.memory.heap.allocated")
+        val ATTR_HEAP_FREE: AttributeKey<Long> = AttributeKey.longKey("process.memory.heap.free")
+        val ATTR_NATIVE_USED: AttributeKey<Long> = AttributeKey.longKey("process.memory.native.used")
+        val ATTR_PSS_KB: AttributeKey<Long> = AttributeKey.longKey("process.memory.pss")
+        val ATTR_THREAD_COUNT: AttributeKey<Long> = AttributeKey.longKey("process.thread.count")
+
+        // Device
+        val ATTR_SYS_MEM_TOTAL: AttributeKey<Long> = AttributeKey.longKey("system.memory.total")
+        val ATTR_SYS_MEM_AVAILABLE: AttributeKey<Long> = AttributeKey.longKey("system.memory.available")
+        val ATTR_SYS_MEM_LOW: AttributeKey<Long> = AttributeKey.longKey("system.memory.low")
+        val ATTR_BATTERY_LEVEL: AttributeKey<Double> = AttributeKey.doubleKey("system.battery.level")
+        val ATTR_BATTERY_TEMP: AttributeKey<Double> = AttributeKey.doubleKey("system.battery.temperature")
+        val ATTR_DISK_FREE: AttributeKey<Long> = AttributeKey.longKey("system.disk.free")
+        val ATTR_DISK_TOTAL: AttributeKey<Long> = AttributeKey.longKey("system.disk.total")
+    }
+}

--- a/instrumentation/system-metrics/src/test/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/DeviceMetricsReaderTest.kt
+++ b/instrumentation/system-metrics/src/test/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/DeviceMetricsReaderTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.systemmetrics
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(AndroidJUnit4::class)
+class DeviceMetricsReaderTest {
+    private val context = RuntimeEnvironment.getApplication()
+    private val reader = DeviceMetricsReader(context)
+
+    @Test
+    fun `readTotalRamBytes returns non-negative value`() {
+        // Robolectric stubs ActivityManager.getMemoryInfo() with totalMem=0;
+        // on a real device this will be positive.
+        assertThat(reader.readTotalRamBytes()).isGreaterThanOrEqualTo(0L)
+    }
+
+    @Test
+    fun `readAvailableRamBytes returns non-negative value`() {
+        assertThat(reader.readAvailableRamBytes()).isGreaterThanOrEqualTo(0L)
+    }
+
+    @Test
+    fun `readAvailableRamBytes is less than or equal to total`() {
+        assertThat(reader.readAvailableRamBytes()).isLessThanOrEqualTo(reader.readTotalRamBytes())
+    }
+
+    @Test
+    fun `readLowMemoryFlag returns 0 or 1`() {
+        val flag = reader.readLowMemoryFlag()
+        assertThat(flag).isIn(0L, 1L)
+    }
+
+    @Test
+    fun `readDiskFreeBytes returns non-negative value`() {
+        assertThat(reader.readDiskFreeBytes()).isGreaterThanOrEqualTo(0L)
+    }
+
+    @Test
+    fun `readDiskTotalBytes returns non-negative value`() {
+        // Robolectric stubs StatFs with blockCount=0; on a real device this will be positive.
+        assertThat(reader.readDiskTotalBytes()).isGreaterThanOrEqualTo(0L)
+    }
+
+    @Test
+    fun `readDiskFreeBytes is less than or equal to total`() {
+        assertThat(reader.readDiskFreeBytes()).isLessThanOrEqualTo(reader.readDiskTotalBytes())
+    }
+}

--- a/instrumentation/system-metrics/src/test/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsReadersTest.kt
+++ b/instrumentation/system-metrics/src/test/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsReadersTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.systemmetrics
+
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SystemMetricsReadersTest {
+    @Test
+    fun `readHeapUsedBytes returns positive value`() {
+        val reader = MemoryMetricsReader()
+        assertThat(reader.readHeapUsedBytes()).isGreaterThan(0L)
+    }
+
+    @Test
+    fun `readNativeHeapUsedBytes returns non-negative value`() {
+        val reader = MemoryMetricsReader()
+        assertThat(reader.readNativeHeapUsedBytes()).isGreaterThanOrEqualTo(0L)
+    }
+
+    @Test
+    fun `readCpuUsagePercent first call returns zero or non-negative value`() {
+        val reader = CpuMetricsReader()
+        // First call: no prior sample delta, should return ~0.0 (no CPU was used yet)
+        // Uses Process.getElapsedCpuTime() which is thread-safe and always available
+        assertThat(reader.readCpuUsagePercent()).isGreaterThanOrEqualTo(0.0).isLessThanOrEqualTo(100.0)
+    }
+
+    @Test
+    fun `readCpuUsagePercent second call returns percentage between 0-100`() {
+        val reader = CpuMetricsReader()
+        reader.readCpuUsagePercent() // seed the baseline
+
+        // Do some work so CPU time advances
+        var sum = 0L
+        for (i in 0 until 100_000) {
+            sum += i
+        }
+
+        val usage = reader.readCpuUsagePercent()
+        assertThat(usage).isGreaterThanOrEqualTo(0.0).isLessThanOrEqualTo(100.0)
+    }
+
+    @Test
+    fun `readThreadCount returns positive value`() {
+        val reader = ThreadMetricsReader()
+        assertThat(reader.readThreadCount()).isGreaterThan(0L)
+    }
+
+    @Test
+    fun `readThreadCountByState includes RUNNABLE state`() {
+        val reader = ThreadMetricsReader()
+        val states = reader.readThreadCountByState()
+        assertThat(states).containsKey("RUNNABLE")
+        assertThat(states["RUNNABLE"]).isGreaterThan(0L)
+    }
+
+    @Test
+    fun `gauges are registered and produce metrics`() {
+        val metricReader = InMemoryMetricReader.create()
+        val meterProvider =
+            SdkMeterProvider
+                .builder()
+                .registerMetricReader(metricReader)
+                .build()
+
+        // Register gauges using the SDK meter directly
+        val meter = meterProvider.get("io.opentelemetry.android.system-metrics")
+        val memoryReader = MemoryMetricsReader()
+
+        meter
+            .gaugeBuilder("test.heap.used")
+            .setUnit("By")
+            .ofLongs()
+            .buildWithCallback { m -> m.record(memoryReader.readHeapUsedBytes()) }
+
+        metricReader.forceFlush()
+        val metrics = metricReader.collectAllMetrics()
+
+        assertThat(metrics).anyMatch { it.name == "test.heap.used" }
+        val heapMetric = metrics.first { it.name == "test.heap.used" }
+        assertThat(heapMetric.longGaugeData.points).isNotEmpty
+        assertThat(heapMetric.longGaugeData.points.first().value).isGreaterThan(0L)
+    }
+}

--- a/instrumentation/system-metrics/src/test/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsSpanEmitterTest.kt
+++ b/instrumentation/system-metrics/src/test/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsSpanEmitterTest.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.systemmetrics
+
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Stub DeviceMetricsReader that avoids real Android context dependencies.
+ */
+internal class StubDeviceMetricsReader : DeviceMetricsReader(mockk(relaxed = true)) {
+    override fun readTotalRamBytes() = 1_000_000L
+    override fun readAvailableRamBytes() = 500_000L
+    override fun readLowMemoryFlag() = 0L
+    override fun readBatteryPercent() = 75.0
+    override fun readBatteryTemperatureCelsius() = 30.0
+    override fun readDiskFreeBytes() = 10_000_000L
+    override fun readDiskTotalBytes() = 100_000_000L
+}
+
+class SystemMetricsSpanEmitterTest {
+    private lateinit var spanExporter: InMemorySpanExporter
+    private lateinit var registry: ActiveSpanRegistry
+    private lateinit var tracerProvider: SdkTracerProvider
+    private lateinit var openTelemetry: OpenTelemetrySdk
+
+    @BeforeEach
+    fun setUp() {
+        spanExporter = InMemorySpanExporter.create()
+        registry = ActiveSpanRegistry()
+        tracerProvider =
+            SdkTracerProvider
+                .builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+                .addSpanProcessor(registry)
+                .build()
+        openTelemetry =
+            OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .build()
+    }
+
+    @Test
+    fun `emits standalone app-metrics span when no user span is active`() {
+        val scheduler = Executors.newSingleThreadScheduledExecutor()
+        val emitter =
+            SystemMetricsSpanEmitter(
+                openTelemetry = openTelemetry,
+                scheduler = scheduler,
+                intervalSeconds = 2L,
+                activeSpanRegistry = registry,
+                deviceReader = StubDeviceMetricsReader(),
+            )
+
+        emitter.start()
+        // sub-sampler fires at t=1s, emitter fires at t=2s — window has ≥1 sample
+        scheduler.awaitTermination(3_500, TimeUnit.MILLISECONDS)
+        scheduler.shutdownNow()
+
+        val spans = spanExporter.finishedSpanItems
+        assertThat(spans).isNotEmpty
+        val metricsSpan = spans.first { it.name == "app.metrics" }
+        val event = metricsSpan.events.first { it.name == "app.metrics" }
+        assertThat(event.attributes.get(SystemMetricsSpanEmitter.ATTR_CPU_USAGE)).isNotNull
+        assertThat(event.attributes.get(SystemMetricsSpanEmitter.ATTR_CPU_MIN)).isNotNull
+        assertThat(event.attributes.get(SystemMetricsSpanEmitter.ATTR_CPU_MAX)).isNotNull
+        assertThat(event.attributes.get(SystemMetricsSpanEmitter.ATTR_HEAP_USED)).isNotNull
+        assertThat(event.attributes.get(SystemMetricsSpanEmitter.ATTR_THREAD_COUNT)).isNotNull
+    }
+
+    @Test
+    fun `attaches app-metrics event to active user span instead of emitting standalone`() {
+        val scheduler = Executors.newSingleThreadScheduledExecutor()
+        val emitter =
+            SystemMetricsSpanEmitter(
+                openTelemetry = openTelemetry,
+                scheduler = scheduler,
+                intervalSeconds = 2L,
+                activeSpanRegistry = registry,
+                deviceReader = StubDeviceMetricsReader(),
+            )
+
+        // Start a user span BEFORE the emitter fires — registry picks it up via onStart().
+        val userSpan =
+            openTelemetry.tracerProvider
+                .get("test")
+                .spanBuilder("UserAction")
+                .startSpan()
+
+        emitter.start()
+        scheduler.awaitTermination(3_500, TimeUnit.MILLISECONDS)
+        scheduler.shutdownNow()
+
+        userSpan.end()
+
+        val finishedSpans = spanExporter.finishedSpanItems
+        val userSpanData = finishedSpans.first { it.name == "UserAction" }
+
+        // Metrics event must be on the user span, not emitted as a separate span.
+        assertThat(userSpanData.events).anyMatch { it.name == "app.metrics" }
+        assertThat(finishedSpans.none { it.name == "app.metrics" }).isTrue
+
+        // Verify CPU min/max are present on the event.
+        val event = userSpanData.events.first { it.name == "app.metrics" }
+        assertThat(event.attributes.get(SystemMetricsSpanEmitter.ATTR_CPU_MIN)).isNotNull
+        assertThat(event.attributes.get(SystemMetricsSpanEmitter.ATTR_CPU_MAX)).isNotNull
+    }
+
+    @Test
+    fun `standalone span carries all process and device metric attributes including min and max`() {
+        val scheduler = Executors.newSingleThreadScheduledExecutor()
+        val emitter =
+            SystemMetricsSpanEmitter(
+                openTelemetry = openTelemetry,
+                scheduler = scheduler,
+                intervalSeconds = 2L,
+                activeSpanRegistry = registry,
+                deviceReader = StubDeviceMetricsReader(),
+            )
+
+        emitter.start()
+        scheduler.awaitTermination(3_500, TimeUnit.MILLISECONDS)
+        scheduler.shutdownNow()
+
+        val metricsSpan = spanExporter.finishedSpanItems.first { it.name == "app.metrics" }
+        val event = metricsSpan.events.first { it.name == "app.metrics" }
+
+        // Process attrs — current values
+        assertThat(event.attributes.get(SystemMetricsSpanEmitter.ATTR_CPU_USAGE)).isNotNull
+        assertThat(event.attributes.get(SystemMetricsSpanEmitter.ATTR_HEAP_USED)).isNotNull
+        assertThat(event.attributes.get(SystemMetricsSpanEmitter.ATTR_HEAP_ALLOCATED)).isNotNull
+        assertThat(event.attributes.get(SystemMetricsSpanEmitter.ATTR_HEAP_FREE)).isNotNull
+        assertThat(event.attributes.get(SystemMetricsSpanEmitter.ATTR_NATIVE_USED)).isNotNull
+        assertThat(event.attributes.get(SystemMetricsSpanEmitter.ATTR_THREAD_COUNT)).isNotNull
+
+        // CPU min/max window attrs
+        assertThat(event.attributes.get(SystemMetricsSpanEmitter.ATTR_CPU_MIN)).isNotNull
+        assertThat(event.attributes.get(SystemMetricsSpanEmitter.ATTR_CPU_MAX)).isNotNull
+    }
+}


### PR DESCRIPTION
Adds a new system-metrics instrumentation module that collects process and device metrics and emits them as span events.

Process metrics (collected every emit interval):
- process.cpu.usage / .min / .max  (delta-based, 1s sub-sampler)
- process.memory.heap.used / .allocated / .free
- process.memory.native.used
- process.memory.pss
- process.thread.count

Device metrics (cached every 60s):
- system.memory.total / .available / .low
- system.battery.level / .temperature
- system.disk.free / .total

Emission strategy:
- If a user span is active: attaches an app.metrics event to it
- Otherwise: emits a standalone app.metrics span with the event

Key implementation details:
- ActiveSpanRegistry (SpanProcessor) tracks the most recently started span
- 1-second CPU sub-sampler feeds min/max window between emissions
- Device metrics cached via @Volatile fields to avoid binder calls on emit path
- AtomicBoolean install guard prevents double-install from ServiceLoader + manual call
- Default collection interval: 30 seconds