### PR TITLE
feat(system-metrics): remove emitAsSpans flag, always emit span events

### DIFF
--- a/instrumentation/system-metrics/api/system-metrics.api
+++ b/instrumentation/system-metrics/api/system-metrics.api
@@ -1,10 +1,8 @@
 public final class io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
 	public fun <init> ()V
 	public final fun getCollectionInterval ()Ljava/time/Duration;
-	public final fun getEmitAsSpans ()Z
 	public fun getName ()Ljava/lang/String;
 	public fun install (Landroid/content/Context;Lio/opentelemetry/android/OpenTelemetryRum;)V
 	public final fun setCollectionInterval (Ljava/time/Duration;)V
-	public final fun setEmitAsSpans (Z)V
 }
 

--- a/instrumentation/system-metrics/src/main/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsInstrumentation.kt
+++ b/instrumentation/system-metrics/src/main/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsInstrumentation.kt
@@ -31,14 +31,6 @@ class SystemMetricsInstrumentation : AndroidInstrumentation {
     /** Interval at which all system metrics are sampled. Default: 30 seconds. */
     var collectionInterval: Duration = Duration.ofSeconds(30)
 
-    /**
-     * When true, emits a `process.system.metrics` span every [collectionInterval] with all
-     * metric values as span attributes. Useful for trace-only backends (Jaeger, Zipkin) or
-     * when metric snapshots need to be stitched into a trace.
-     * Default: false (metrics-only via ObservableGauge).
-     */
-    var emitAsSpans: Boolean = false
-
     override val name: String = "system-metrics"
 
     private val installed = AtomicBoolean(false)
@@ -62,20 +54,16 @@ class SystemMetricsInstrumentation : AndroidInstrumentation {
         registerProcessMetrics(meter, cpuReader, memoryReader, threadReader)
         registerDeviceMetrics(meter, deviceReader)
 
-        if (emitAsSpans) {
-            val registry = ActiveSpanRegistry()
-            // Inject the registry as a SpanProcessor into the already-built SdkTracerProvider
-            // so it receives onStart/onEnd callbacks for every span created in the app.
-            val sdk = openTelemetryRum.openTelemetry as? OpenTelemetrySdk
-            sdk?.let { injectSpanProcessor(it, registry) }
-            SystemMetricsSpanEmitter(
-                openTelemetry = openTelemetryRum.openTelemetry,
-                scheduler = Executors.newSingleThreadScheduledExecutor(),
-                intervalSeconds = collectionInterval.seconds,
-                activeSpanRegistry = registry,
-                deviceReader = deviceReader,
-            ).start()
-        }
+        val registry = ActiveSpanRegistry()
+        val sdk = openTelemetryRum.openTelemetry as? OpenTelemetrySdk
+        sdk?.let { injectSpanProcessor(it, registry) }
+        SystemMetricsSpanEmitter(
+            openTelemetry = openTelemetryRum.openTelemetry,
+            scheduler = Executors.newSingleThreadScheduledExecutor(),
+            intervalSeconds = collectionInterval.seconds,
+            activeSpanRegistry = registry,
+            deviceReader = deviceReader,
+        ).start()
     }
 
     private fun registerProcessMetrics(


### PR DESCRIPTION
The emitAsSpans flag was originally added to allow opting in to span emission, but the instrumentation's primary value is the trace-based app.metrics event. Having a flag creates unnecessary surface area and diverges from the pattern of other instrumentations (e.g. hybrid-click) which are fully self-contained.

Remove the flag so the single auto-discovered instance always:
- Registers ObservableGauges for CPU, memory, battery, disk, threads
- Injects ActiveSpanRegistry via reflection to track the current span
- Emits an app.metrics event on the active span every collectionInterval, falling back to a standalone span when no user span is in flight

This removes the need for any manual install() call in Vunet.kt or equivalent application code.