### PR TITLE
feat(startup): add early startup events and TTID to AppStart span

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -1,3 +1,9 @@
+public final class io/opentelemetry/android/common/ProcessStartTimestamps {
+	public static final field INSTANCE Lio/opentelemetry/android/common/ProcessStartTimestamps;
+	public static field attachBaseContextEpochMs J
+	public static field contentProviderEpochMs J
+}
+
 public final class io/opentelemetry/android/common/RumConstants {
 	public static final field APP_START_SPAN_NAME Ljava/lang/String;
 	public static final field BATTERY_PERCENT_KEY Lio/opentelemetry/api/common/AttributeKey;

--- a/common/src/main/java/io/opentelemetry/android/common/ProcessStartTimestamps.kt
+++ b/common/src/main/java/io/opentelemetry/android/common/ProcessStartTimestamps.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.common
+
+/**
+ * Cross-module holder for process-level timing captured before the OpenTelemetry SDK initialises.
+ *
+ * Fields are written exactly once by
+ * [io.opentelemetry.android.instrumentation.startup.EarlyStartupContentProvider] on the main
+ * thread, before [android.app.Application.onCreate] runs. They are subsequently read by
+ * [io.opentelemetry.android.instrumentation.activity.startup.AppStartupTimer] when it creates the
+ * `AppStart` span, allowing startup events to be back-dated to their true wall-clock origin.
+ *
+ * Thread safety: each field is `@Volatile`. The write happens on the main thread during
+ * ContentProvider init; if anything reads from a background thread, `@Volatile` guarantees
+ * visibility without requiring a lock.
+ *
+ * All values are 0 when the startup instrumentation is not on the classpath.
+ */
+object ProcessStartTimestamps {
+    /**
+     * `System.currentTimeMillis()` (epoch ms) recorded by
+     * [io.opentelemetry.android.instrumentation.startup.AppAnchorContentProvider] — a
+     * ContentProvider declared with `android:initOrder="2147483647"` so it fires before any
+     * third-party library provider (Firebase, WorkManager, etc.).
+     *
+     * This is the earliest moment after `Application.attachBaseContext()` completed and just
+     * before any library ContentProvider initialises. Used to emit the `app.base_context`
+     * milestone event on the `AppStart` span.
+     */
+    @Volatile
+    @JvmField
+    var attachBaseContextEpochMs: Long = 0L
+
+    /**
+     * `System.currentTimeMillis()` (epoch ms) recorded the moment
+     * [io.opentelemetry.android.instrumentation.startup.EarlyStartupContentProvider.onCreate]
+     * returned. This is the earliest moment any library code can run — after the process was forked
+     * and `Application.attachBaseContext()` completed, but before `Application.onCreate()`.
+     *
+     * Used to emit the `app.init.contentprovider` milestone event on the `AppStart` span.
+     */
+    @Volatile
+    @JvmField
+    var contentProviderEpochMs: Long = 0L
+}

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityCallbacks.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityCallbacks.kt
@@ -57,7 +57,7 @@ internal class ActivityCallbacks(
         tracers
             .addEvent(activity, "activityPostResumed")
             .addPreviousScreenAttribute()
-            .endSpanForActivityResumed()
+        tracers.deferEndForTtid(activity)
     }
 
     override fun onActivityPrePaused(activity: Activity) {

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityTracer.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityTracer.kt
@@ -6,6 +6,9 @@
 package io.opentelemetry.android.instrumentation.activity
 
 import android.app.Activity
+import android.os.Build
+import android.view.ViewTreeObserver
+import androidx.annotation.RequiresApi
 import io.opentelemetry.android.common.RumConstants.APP_START_SPAN_NAME
 import io.opentelemetry.android.common.RumConstants.SCREEN_NAME_KEY
 import io.opentelemetry.android.common.RumConstants.START_TYPE_KEY
@@ -103,6 +106,68 @@ internal class ActivityTracer(
         endActiveSpan()
     }
 
+    /**
+     * Defers ending the current span until the Activity's window draws its first frame
+     * (Time To Initial Display). On first [ViewTreeObserver.OnDrawListener.onDraw] callback:
+     *   1. Adds a `ttid` event to mark the exact frame-draw moment.
+     *   2. Ends the span and releases the listener.
+     *
+     * Falls back to [endSpanForActivityResumed] immediately if:
+     * - The decor view is not yet attached (ViewTreeObserver not alive), or
+     * - Running below API 26 ([ViewTreeObserver.addOnDrawListener] requires API 26+
+     *   to be safely removed from within the callback via
+     *   [ViewTreeObserver.removeOnDrawListener]).
+     */
+    fun deferEndForTtid(activity: Activity) {
+        if (initialAppActivity == null) {
+            initialAppActivity = activityName
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            endActiveSpan()
+            return
+        }
+        val decorView = activity.window?.decorView
+        val vto = decorView?.viewTreeObserver
+        if (vto == null || !vto.isAlive) {
+            endActiveSpan()
+            return
+        }
+        val spanToEnd: Span = activeSpan.currentSpan() ?: run {
+            endActiveSpan()
+            return
+        }
+        // Close the OTel scope immediately so this span is no longer the current context.
+        // Without this, any subsequent spans (e.g. click events) would be parented to the
+        // AppStart span while the TTID listener waits for the first draw.
+        activeSpan.closeScope()
+        registerTtidListener(activity, vto, spanToEnd)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun registerTtidListener(
+        activity: Activity,
+        vto: ViewTreeObserver,
+        spanToEnd: Span,
+    ) {
+        var listener: ViewTreeObserver.OnDrawListener? = null
+        listener = ViewTreeObserver.OnDrawListener {
+            spanToEnd.addEvent(EVENT_TTID)
+            // End span directly (scope was already closed in deferEndForTtid) and clear the
+            // reference so spanInProgress() returns false for any subsequent lifecycle events.
+            spanToEnd.end()
+            activeSpan.clearSpan()
+            appStartupTimer.end()
+            // Post removal — removing an OnDrawListener from within onDraw is not safe
+            // on all versions; posting to the view's handler defers it to after the frame.
+            activity.window?.decorView?.post {
+                activity.window?.decorView?.viewTreeObserver
+                    ?.takeIf { it.isAlive }
+                    ?.removeOnDrawListener(listener)
+            }
+        }
+        vto.addOnDrawListener(listener)
+    }
+
     fun endActiveSpan() {
         // If we happen to be in app startup, make sure this ends it. It's harmless if we're already
         // out of the startup phase.
@@ -122,5 +187,8 @@ internal class ActivityTracer(
 
     internal companion object {
         val ACTIVITY_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("activity.name")
+
+        /** Milestone: first frame drawn on screen — Time To Initial Display. */
+        const val EVENT_TTID = "ttid"
     }
 }

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityTracerCache.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityTracerCache.kt
@@ -56,6 +56,8 @@ internal class ActivityTracerCache
 
         fun startActivityCreation(activity: Activity): ActivityTracer = getTracer(activity).startActivityCreation()
 
+        fun deferEndForTtid(activity: Activity): ActivityTracer = getTracer(activity).also { it.deferEndForTtid(activity) }
+
         private fun getTracer(activity: Activity): ActivityTracer =
             tracersByActivityClassName.getOrPut(activity.javaClass.name) {
                 tracerFactory(activity)

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer.kt
@@ -7,10 +7,16 @@ package io.opentelemetry.android.instrumentation.activity.startup
 
 import android.app.Activity
 import android.app.Application.ActivityLifecycleCallbacks
+import android.os.Build
 import android.os.Bundle
+import android.os.Process
+import android.os.SystemClock
 import android.util.Log
+import androidx.annotation.RequiresApi
+import io.opentelemetry.android.common.ProcessStartTimestamps
 import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.android.internal.services.visiblescreen.activities.DefaultingActivityLifecycleCallbacks
+import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.common.Clock
@@ -42,14 +48,77 @@ internal class AppStartupTimer {
         }
         startupClock = AnchoredClock(clock)
         firstPossibleTimestamp = startupClock.now()
+        // On API 24+, backdate the span to the true process fork time so that the
+        // app.process.creation and app.init.contentprovider events fall inside the span.
+        // On API 23, fall back to firstPossibleTimestamp (SDK init time).
+        val spanStartNanos =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                processStartEpochMs() * 1_000_000L
+            } else {
+                firstPossibleTimestamp
+            }
         val appStart =
             tracer
                 .spanBuilder("AppStart")
-                .setStartTimestamp(firstPossibleTimestamp, TimeUnit.NANOSECONDS)
+                .setStartTimestamp(spanStartNanos, TimeUnit.NANOSECONDS)
                 .setAttribute(RumConstants.START_TYPE_KEY, "cold")
                 .startSpan()
         this.startupSpan = appStart
+        addEarlyStartupEvents(appStart)
+        // firstPossibleTimestamp is captured right now — when the SDK finishes building
+        // inside Application.onCreate(). This is a reliable marker for the end of
+        // Application.onCreate() since SDK init is typically the last step there.
+        appStart.addEvent(
+            EVENT_APPLICATION_ON_CREATE_POST,
+            Attributes.empty(),
+            firstPossibleTimestamp / 1_000_000L,
+            TimeUnit.MILLISECONDS,
+        )
         return appStart
+    }
+
+    /**
+     * Back-dates process-level milestones onto the AppStart span using timestamps that were
+     * captured before the OTel SDK was initialised.
+     *
+     * app.process.creation — derived from [Process.getStartElapsedRealtime] (API 24+).
+     *   Silently omitted on API 23.
+     *
+     * app.init.contentprovider — recorded by [EarlyStartupContentProvider] before
+     *   Application.onCreate(); present only when the startup instrumentation artifact is on
+     *   the classpath. Silently omitted when the value is 0 (provider did not run).
+     */
+    private fun addEarlyStartupEvents(appStart: Span) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            appStart.addEvent(
+                EVENT_PROCESS_CREATION,
+                Attributes.empty(),
+                processStartEpochMs(),
+                TimeUnit.MILLISECONDS,
+            )
+        }
+        val bcMs = ProcessStartTimestamps.attachBaseContextEpochMs
+        if (bcMs > 0L) {
+            appStart.addEvent(EVENT_BASE_CONTEXT, Attributes.empty(), bcMs, TimeUnit.MILLISECONDS)
+        }
+        val cpMs = ProcessStartTimestamps.contentProviderEpochMs
+        if (cpMs > 0L) {
+            appStart.addEvent(EVENT_CONTENT_PROVIDER_INIT, Attributes.empty(), cpMs, TimeUnit.MILLISECONDS)
+            appStart.addEvent(EVENT_APPLICATION_PRE_CREATED, Attributes.empty(), cpMs, TimeUnit.MILLISECONDS)
+        }
+    }
+
+    /**
+     * Converts [Process.getStartElapsedRealtime] to a wall-clock epoch value:
+     *   processStartEpochMs = nowMs − (elapsedRealtime − processStartElapsedRealtime)
+     *
+     * Assumes the wall clock was not adjusted between process fork and now, which is safe
+     * for the typical sub-second cold-start window.
+     */
+    @RequiresApi(Build.VERSION_CODES.N)
+    private fun processStartEpochMs(): Long {
+        val nowMs = System.currentTimeMillis()
+        return nowMs - (SystemClock.elapsedRealtime() - Process.getStartElapsedRealtime())
     }
 
     /**
@@ -59,6 +128,25 @@ internal class AppStartupTimer {
      */
     fun createLifecycleCallback(): ActivityLifecycleCallbacks =
         object : DefaultingActivityLifecycleCallbacks {
+            private var appPostCreatedEmitted = false
+
+            override fun onActivityPreCreated(
+                activity: Activity,
+                savedInstanceState: Bundle?,
+            ) {
+                // Fires immediately after Application.onCreate() returns and the OS hands
+                // control to the first Activity. Emit only once — for the very first Activity.
+                if (!appPostCreatedEmitted) {
+                    appPostCreatedEmitted = true
+                    startupSpan?.addEvent(
+                        EVENT_APPLICATION_POST_CREATED,
+                        Attributes.empty(),
+                        System.currentTimeMillis(),
+                        TimeUnit.MILLISECONDS,
+                    )
+                }
+            }
+
             override fun onActivityCreated(
                 activity: Activity,
                 savedInstanceState: Bundle?,
@@ -97,5 +185,40 @@ internal class AppStartupTimer {
         // create the app start span. Long app startup could indicate that the app was really started in
         // background, in which case the measured startup time is misleading.
         private val MAX_TIME_TO_UI_INIT = TimeUnit.MINUTES.toNanos(1)
+
+        /** Milestone: Linux process was forked. Backdated via [Process.getStartElapsedRealtime]. */
+        internal const val EVENT_PROCESS_CREATION = "app.process.creation"
+
+        /**
+         * Milestone: Application.attachBaseContext() completed; captured by
+         * [AppAnchorContentProvider] which fires before any third-party library provider.
+         */
+        internal const val EVENT_BASE_CONTEXT = "app.base_context"
+
+        /**
+         * Milestone: ContentProviders finished initialising (last moment before
+         * Application.onCreate). Present only when the startup instrumentation artifact is
+         * on the classpath.
+         */
+        internal const val EVENT_CONTENT_PROVIDER_INIT = "app.init.contentprovider"
+
+        /**
+         * Milestone: Application.onCreate() is about to start. Fires at the same instant as
+         * [EVENT_CONTENT_PROVIDER_INIT] but mirrors the Activity lifecycle naming pattern.
+         */
+        internal const val EVENT_APPLICATION_PRE_CREATED = "applicationPreCreated"
+
+        /**
+         * Milestone: OTel SDK built inside Application.onCreate() = the app's core
+         * initialisation is done. Mirrors activityCreated.
+         */
+        internal const val EVENT_APPLICATION_ON_CREATE_POST = "applicationCreated"
+
+        /**
+         * Milestone: Application.onCreate() returned = OS is handing control to the first
+         * Activity. Captured on the first onActivityPreCreated callback.
+         * Mirrors activityPostCreated.
+         */
+        internal const val EVENT_APPLICATION_POST_CREATED = "applicationPostCreated"
     }
 }

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentationTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentationTest.kt
@@ -56,6 +56,7 @@ class ActivityLifecycleInstrumentationTest {
             startupSpanBuilder,
         )
         every { startupSpanBuilder.startSpan() }.returns(startupSpan)
+        every { startupSpan.addEvent(any<String>(), any(), any<Long>(), any()) }.returns(startupSpan)
 
         val openTelemetryRum = mockk<OpenTelemetryRum>()
         every { openTelemetryRum.openTelemetry } returns openTelemetry

--- a/instrumentation/common-api/api/common-api.api
+++ b/instrumentation/common-api/api/common-api.api
@@ -6,6 +6,9 @@ public final class io/opentelemetry/android/instrumentation/common/ActiveSpan {
 	public fun <init> (Lkotlin/jvm/functions/Function0;)V
 	public final fun addEvent (Ljava/lang/String;)V
 	public final fun addPreviousScreenAttribute (Ljava/lang/String;)V
+	public final fun clearSpan ()V
+	public final fun closeScope ()V
+	public final fun currentSpan ()Lio/opentelemetry/api/trace/Span;
 	public final fun endActiveSpan ()V
 	public final fun spanInProgress ()Z
 	public final fun startSpan (Lkotlin/jvm/functions/Function0;)V

--- a/instrumentation/common-api/src/main/java/io/opentelemetry/android/instrumentation/common/ActiveSpan.kt
+++ b/instrumentation/common-api/src/main/java/io/opentelemetry/android/instrumentation/common/ActiveSpan.kt
@@ -17,6 +17,9 @@ class ActiveSpan(
 
     fun spanInProgress(): Boolean = span != null
 
+    /** Returns the currently active [Span], or null if none is in progress. */
+    fun currentSpan(): Span? = span
+
     // it's fine to not close the scope here, will be closed in endActiveSpan()
     fun startSpan(spanCreator: () -> Span) {
         // don't start one if there's already one in progress
@@ -36,6 +39,20 @@ class ActiveSpan(
             it.end()
             span = null
         }
+    }
+
+    /**
+     * Closes the OTel [Scope] so this span is no longer the current context, without
+     * ending the span itself. Used when span end must be deferred (e.g. TTID).
+     */
+    fun closeScope() {
+        scope?.close()
+        scope = null
+    }
+
+    /** Clears the span reference after it has been ended externally (e.g. TTID listener). */
+    fun clearSpan() {
+        span = null
     }
 
     fun addEvent(eventName: String) {

--- a/instrumentation/startup/src/main/AndroidManifest.xml
+++ b/instrumentation/startup/src/main/AndroidManifest.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright The OpenTelemetry Authors
+  SPDX-License-Identifier: Apache-2.0
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <!--
+          AppAnchorContentProvider fires FIRST — before Firebase, WorkManager, and any other
+          library ContentProvider — because android:initOrder is set to Integer.MAX_VALUE.
+          It captures the wall-clock time immediately after Application.attachBaseContext()
+          completed, before any third-party SDK has had a chance to run.
+          Used to emit the app.base_context milestone event on the AppStart span.
+        -->
+        <provider
+            android:name=".AppAnchorContentProvider"
+            android:authorities="${applicationId}.otel.android.app_anchor"
+            android:exported="false"
+            android:initOrder="2147483647"
+            android:multiprocess="false" />
+
+        <!--
+          EarlyStartupContentProvider fires after all other ContentProviders because it uses
+          the default initOrder (0). It captures the wall-clock time just before
+          Application.onCreate(), after all library providers (Firebase, etc.) have initialised.
+          Used to emit the app.init.contentprovider milestone event on the AppStart span.
+        -->
+        <provider
+            android:name=".EarlyStartupContentProvider"
+            android:authorities="${applicationId}.otel.android.early_startup"
+            android:exported="false"
+            android:multiprocess="false" />
+    </application>
+
+</manifest>

--- a/instrumentation/startup/src/main/java/io/opentelemetry/android/instrumentation/startup/AppAnchorContentProvider.kt
+++ b/instrumentation/startup/src/main/java/io/opentelemetry/android/instrumentation/startup/AppAnchorContentProvider.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.startup
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import io.opentelemetry.android.common.ProcessStartTimestamps
+
+/**
+ * A zero-overhead [ContentProvider] declared with `android:initOrder="2147483647"` (MAX_INT)
+ * so the Android OS instantiates it before any other ContentProvider in the merged manifest —
+ * including Firebase, WorkManager, or any other third-party library that self-registers via
+ * provider.
+ *
+ * It fires at the earliest possible moment after `Application.attachBaseContext()` completes,
+ * which is before any library code has run. The timestamp is stored in
+ * [ProcessStartTimestamps.attachBaseContextEpochMs] and later emitted as the
+ * `app.base_context` milestone event on the `AppStart` span.
+ *
+ * Security: declared with `android:exported="false"` and `android:multiprocess="false"`.
+ *
+ * No content is served. All resolver operations are no-ops that return null / 0.
+ */
+internal class AppAnchorContentProvider : ContentProvider() {
+
+    override fun onCreate(): Boolean {
+        ProcessStartTimestamps.attachBaseContextEpochMs = System.currentTimeMillis()
+        return false
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(
+        uri: Uri,
+        values: ContentValues?,
+    ): Uri? = null
+
+    override fun delete(
+        uri: Uri,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = 0
+}

--- a/instrumentation/startup/src/main/java/io/opentelemetry/android/instrumentation/startup/EarlyStartupContentProvider.kt
+++ b/instrumentation/startup/src/main/java/io/opentelemetry/android/instrumentation/startup/EarlyStartupContentProvider.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.startup
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import io.opentelemetry.android.common.ProcessStartTimestamps
+
+/**
+ * A zero-overhead [ContentProvider] whose sole job is to stamp
+ * [ProcessStartTimestamps.contentProviderEpochMs] with the current wall-clock time at the
+ * earliest moment library code can execute in the app process.
+ *
+ * Android instantiates ContentProviders — in manifest-declaration order — after
+ * [android.app.Application.attachBaseContext] but **before** [android.app.Application.onCreate].
+ * Registering here gives [io.opentelemetry.android.instrumentation.activity.startup.AppStartupTimer]
+ * a reliable timestamp to back-date the `app.init.contentprovider` milestone onto the
+ * `AppStart` span, eliminating the silent dead-zone between process fork and the first
+ * activity lifecycle callback.
+ *
+ * Security: declared with `android:exported="false"` and `android:multiprocess="false"` so it
+ * is never visible to external processes and runs only in the primary app process.
+ *
+ * No content is served. All resolver operations are no-ops that return null / 0.
+ */
+internal class EarlyStartupContentProvider : ContentProvider() {
+
+    override fun onCreate(): Boolean {
+        ProcessStartTimestamps.contentProviderEpochMs = System.currentTimeMillis()
+        return false
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(
+        uri: Uri,
+        values: ContentValues?,
+    ): Uri? = null
+
+    override fun delete(
+        uri: Uri,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = 0
+}


### PR DESCRIPTION
### Problem

The `AppStart` span previously started at OTel SDK initialisation time (inside `Application.onCreate()`), leaving 200–400 ms of process startup completely invisible in traces. There was also no signal for when the first frame actually appeared on screen.

### Changes

#### common — `ProcessStartTimestamps`
A cross-module `object` with two `@Volatile` fields written by ContentProviders before the OTel SDK exists. Acts as a zero-dependency timestamp relay between the pre-SDK world and `AppStartupTimer`.

#### startup — Two ContentProviders
- **`AppAnchorContentProvider`** — declared with `android:initOrder="2147483647"` (Integer.MAX_VALUE) so it fires before every other provider (Firebase, WorkManager, etc.). Records `System.currentTimeMillis()` into `ProcessStartTimestamps.attachBaseContextEpochMs` — the earliest possible post-`attachBaseContext` timestamp.
- **`EarlyStartupContentProvider`** — default `initOrder`, fires last among all providers. Records `contentProviderEpochMs` — the last moment before `Application.onCreate()` starts.

#### activity — `AppStartupTimer`
- `AppStart` span **start timestamp backdated** to process fork time on API 24+ via:
  ```
  processStartEpochMs = currentTimeMillis() − (elapsedRealtime() − Process.getStartElapsedRealtime())
  ```
- **6 milestone events** added to the span in chronological order:

| Event | Source | When |
|---|---|---|
| `app.process.creation` | `Process.getStartElapsedRealtime()` (API 24+) | Linux process forked from zygote |
| `app.base_context` | `AppAnchorContentProvider` | After `attachBaseContext`, before any library provider |
| `app.init.contentprovider` | `EarlyStartupContentProvider` | All ContentProviders done |
| `applicationPreCreated` | same timestamp as above | Lifecycle-naming alias |
| `applicationCreated` | `AnchoredClock.now()` at SDK build | `Application.onCreate()` complete |
| `applicationPostCreated` | `onActivityPreCreated` callback | `Application.onCreate()` returned, first Activity starting |

#### activity — TTID (Time To Initial Display)
- `onActivityPostResumed` now calls `deferEndForTtid()` instead of immediately ending the span.
- The OTel **scope is closed immediately** (so subsequent spans like button clicks are not parented to `AppStart`), but the span itself stays open.
- A `ViewTreeObserver.OnDrawListener` on `decorView` fires on the **first committed frame**, adds a `ttid` event, and ends the span (API 26+; falls back to immediate end on older APIs).

#### common-api — `ActiveSpan`
Added `closeScope()` (detach context without ending span) and `clearSpan()` (null the span reference after external end) to support the deferred TTID pattern cleanly.