### PR TITLE
fix: flush crash telemetry before runtime kill handler

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -24,6 +24,11 @@ public final class io/opentelemetry/android/common/RumConstants$Events {
 	public static final field INSTANCE Lio/opentelemetry/android/common/RumConstants$Events;
 }
 
+public abstract interface class io/opentelemetry/android/common/UncaughtExceptionHandlerWithDeferredDelegation : java/lang/Thread$UncaughtExceptionHandler {
+	public abstract fun delegateToNext (Ljava/lang/Thread;Ljava/lang/Throwable;)V
+	public abstract fun recordUnhandledException (Ljava/lang/Thread;Ljava/lang/Throwable;)V
+}
+
 public final class io/opentelemetry/android/common/internal/features/networkattributes/CurrentNetworkAttributesExtractor {
 	public fun <init> ()V
 	public final fun extract (Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;)Lio/opentelemetry/api/common/Attributes;

--- a/common/src/main/java/io/opentelemetry/android/common/UncaughtExceptionHandlerWithDeferredDelegation.kt
+++ b/common/src/main/java/io/opentelemetry/android/common/UncaughtExceptionHandlerWithDeferredDelegation.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.common
+
+/**
+ * Splits crash handling into a record step and a delegate step so
+ * [io.opentelemetry.android.CrashFlushHandler] can flush telemetry between them. The delegate step
+ * often invokes the runtime handler, which may terminate the process immediately.
+ */
+interface UncaughtExceptionHandlerWithDeferredDelegation : Thread.UncaughtExceptionHandler {
+    /** Record telemetry for the failure; must not invoke [delegateToNext]. */
+    fun recordUnhandledException(
+        thread: Thread,
+        throwable: Throwable,
+    )
+
+    /** Forward to the next handler (typically ends the process on Android). */
+    fun delegateToNext(
+        thread: Thread,
+        throwable: Throwable,
+    )
+}

--- a/core/src/main/java/io/opentelemetry/android/CrashFlushHandler.kt
+++ b/core/src/main/java/io/opentelemetry/android/CrashFlushHandler.kt
@@ -7,6 +7,7 @@ package io.opentelemetry.android
 
 import android.util.Log
 import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.common.UncaughtExceptionHandlerWithDeferredDelegation
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.common.CompletableResultCode
 import java.util.concurrent.CountDownLatch
@@ -16,7 +17,12 @@ import kotlin.time.Duration.Companion.seconds
 
 /**
  * Installs a [Thread.UncaughtExceptionHandler] that force-flushes all signal
- * providers (traces, logs, metrics) before delegating to the previously set handler.
+ * providers (traces, logs, metrics) after recording the crash but before delegating to
+ * the runtime handler (which often terminates the process immediately).
+ *
+ * Handlers that implement [UncaughtExceptionHandlerWithDeferredDelegation] (crash
+ * instrumentation) are split so we only call [recordUnhandledException] before flush, then
+ * [delegateToNext] after.
  *
  * This ensures that telemetry emitted during a crash (including the crash event itself)
  * is persisted before the process terminates, without requiring individual instrumentations
@@ -31,10 +37,11 @@ internal class CrashFlushHandler(
     }
 
     fun install() {
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler(
             FlushOnCrashExceptionHandler(
                 sdk,
-                Thread.getDefaultUncaughtExceptionHandler(),
+                previous,
                 flushTimeout
             ),
         )
@@ -49,10 +56,14 @@ internal class CrashFlushHandler(
             thread: Thread,
             throwable: Throwable,
         ) {
-            // Let any previously installed handler run first (e.g. the crash
-            // instrumentation emits the crash log record in its handler).
-            previousHandler?.uncaughtException(thread, throwable)
-
+            // Record-only first: the crash handler chains to the runtime handler, which often
+            // kills the process (SIGKILL) before we return — so we must not call full
+            // uncaughtException until after flush.
+            when (val p = previousHandler) {
+                is UncaughtExceptionHandlerWithDeferredDelegation ->
+                    p.recordUnhandledException(thread, throwable)
+                else -> previousHandler?.uncaughtException(thread, throwable)
+            }
             try {
                 awaitCompletion(
                     flushTimeout,
@@ -62,6 +73,13 @@ internal class CrashFlushHandler(
                 )
             } catch (e: Exception) {
                 Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to flush telemetry on crash", e)
+            }
+            when (val p = previousHandler) {
+                is UncaughtExceptionHandlerWithDeferredDelegation ->
+                    p.delegateToNext(thread, throwable)
+                else -> {
+                    // Already ran full previousHandler above (may have killed the process).
+                }
             }
         }
 

--- a/core/src/test/java/io/opentelemetry/android/CrashFlushHandlerTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/CrashFlushHandlerTest.kt
@@ -10,6 +10,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyOrder
+import io.opentelemetry.android.common.UncaughtExceptionHandlerWithDeferredDelegation
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.logs.SdkLoggerProvider
@@ -121,6 +122,34 @@ class CrashFlushHandlerTest {
         verifyOrder {
             existingHandler.uncaughtException(thread, any())
             tracerProvider.forceFlush()
+        }
+    }
+
+    @Test
+    fun `deferred handler records then flushes then delegates`() {
+        val deferred = mockk<UncaughtExceptionHandlerWithDeferredDelegation>(relaxed = true)
+        Thread.setDefaultUncaughtExceptionHandler(deferred)
+
+        val tracerProvider = mockk<SdkTracerProvider>()
+        val loggerProvider = mockk<SdkLoggerProvider>()
+        val meterProvider = mockk<SdkMeterProvider>()
+        val sdk = mockSdk(tracerProvider, loggerProvider, meterProvider)
+
+        every { tracerProvider.forceFlush() } returns CompletableResultCode.ofSuccess()
+        every { loggerProvider.forceFlush() } returns CompletableResultCode.ofSuccess()
+        every { meterProvider.forceFlush() } returns CompletableResultCode.ofSuccess()
+
+        CrashFlushHandler(sdk).install()
+
+        val handler = Thread.getDefaultUncaughtExceptionHandler()!!
+        val thread = Thread.currentThread()
+        val exception = RuntimeException("test")
+        handler.uncaughtException(thread, exception)
+
+        verifyOrder {
+            deferred.recordUnhandledException(thread, exception)
+            tracerProvider.forceFlush()
+            deferred.delegateToNext(thread, exception)
         }
     }
 

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReportingExceptionHandler.kt
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReportingExceptionHandler.kt
@@ -5,17 +5,31 @@
 
 package io.opentelemetry.android.instrumentation.crash
 
+import io.opentelemetry.android.common.UncaughtExceptionHandlerWithDeferredDelegation
+
 internal class CrashReportingExceptionHandler(
     private val crashProcessor: (details: CrashDetails) -> Unit,
     private val existingHandler: Thread.UncaughtExceptionHandler? = Thread.getDefaultUncaughtExceptionHandler(),
-) : Thread.UncaughtExceptionHandler {
+) : UncaughtExceptionHandlerWithDeferredDelegation {
     override fun uncaughtException(
         thread: Thread,
         throwable: Throwable,
     ) {
-        crashProcessor(CrashDetails(thread, throwable))
+        recordUnhandledException(thread, throwable)
+        delegateToNext(thread, throwable)
+    }
 
-        // preserve any existing behavior
+    override fun recordUnhandledException(
+        thread: Thread,
+        throwable: Throwable,
+    ) {
+        crashProcessor(CrashDetails(thread, throwable))
+    }
+
+    override fun delegateToNext(
+        thread: Thread,
+        throwable: Throwable,
+    ) {
         existingHandler?.uncaughtException(thread, throwable)
     }
 }


### PR DESCRIPTION
CrashReportingExceptionHandler chains to the Android runtime handler, which often SIGKILLs the process before returning. CrashFlushHandler previously invoked the full previous handler first, so forceFlush never ran.

Introduce UncaughtExceptionHandlerWithDeferredDelegation: record crash, flush, then delegate. Crash instrumentation implements the split contract.