### PR TITLE
startup: implement TTID and application lifecycle milestone events

### DIFF
--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer.kt
@@ -17,11 +17,13 @@ import io.opentelemetry.android.common.StartupTimestampProvider
 import java.util.ServiceLoader
 import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.android.internal.services.visiblescreen.activities.DefaultingActivityLifecycleCallbacks
+import android.view.ViewTreeObserver
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.common.Clock
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 internal class AppStartupTimer(
     timestampProvider: StartupTimestampProvider? = null,
@@ -47,6 +49,18 @@ internal class AppStartupTimer(
     // whether MAX_TIME_TO_UI_INIT has been exceeded
     // accessed only from UI thread
     private var uiInitTooLate = false
+
+    // guards applicationPostCreated so it fires only for the first activity;
+    // in BFSI apps a second activity (biometric/splash) can fire before the first frame
+    private val postCreatedFired = AtomicBoolean(false)
+
+    // true once a TTID OnDrawListener has been attached to the first activity's decorView;
+    // used by end() to yield to the draw listener instead of ending the span prematurely
+    @Volatile
+    private var ttidListenerAttached = false
+
+    // true once the first-frame draw has been detected and the ttid event emitted
+    private val ttidFired = AtomicBoolean(false)
 
     fun start(
         tracer: Tracer,
@@ -108,7 +122,24 @@ internal class AppStartupTimer(
                 contentProviderMs,
                 TimeUnit.MILLISECONDS,
             )
+            // applicationPreCreated is a semantic alias for the same timestamp — it marks
+            // the boundary where the OS hands control to Application.onCreate().
+            appStart.addEvent(
+                EVENT_APPLICATION_PRE_CREATED,
+                Attributes.empty(),
+                contentProviderMs,
+                TimeUnit.MILLISECONDS,
+            )
         }
+
+        // applicationCreated — SDK init is complete; all of Application.onCreate() that
+        // ran before the OTel SDK initialised has now been accounted for.
+        appStart.addEvent(
+            EVENT_APPLICATION_CREATED,
+            Attributes.empty(),
+            startupClock.now(),
+            TimeUnit.NANOSECONDS,
+        )
 
         return appStart
     }
@@ -136,11 +167,64 @@ internal class AppStartupTimer(
      */
     fun createLifecycleCallback(): ActivityLifecycleCallbacks =
         object : DefaultingActivityLifecycleCallbacks {
+            override fun onActivityPreCreated(
+                activity: Activity,
+                savedInstanceState: Bundle?,
+            ) {
+                // Emit only for the first activity. In apps with biometric/splash flows
+                // a second activity can fire before the first frame, corrupting the timestamp.
+                if (!postCreatedFired.compareAndSet(false, true)) return
+                startupSpan?.addEvent(
+                    EVENT_APPLICATION_POST_CREATED,
+                    Attributes.empty(),
+                    startupClock.now(),
+                    TimeUnit.NANOSECONDS,
+                )
+            }
+
             override fun onActivityCreated(
                 activity: Activity,
                 savedInstanceState: Bundle?,
             ) {
                 startUiInit()
+            }
+
+            override fun onActivityResumed(activity: Activity) {
+                // Only attach during startup and only once.
+                if (ttidFired.get() || startupSpan == null) return
+
+                // Skip system / biometric overlay activities so the TTID is captured
+                // against the app's own first activity, not an Android system dialog.
+                val className = activity.javaClass.name
+                if (className.startsWith("android.") || className.startsWith("com.android.")) return
+
+                val rootView = activity.window.decorView
+
+                // Keep a reference so we can remove the listener from outside onDraw().
+                // (Removing from within onDraw() itself is not safe on all API levels.)
+                var listener: ViewTreeObserver.OnDrawListener? = null
+                listener = ViewTreeObserver.OnDrawListener {
+                    // Post to the next looper cycle — the frame is committed to SurfaceFlinger
+                    // after this Runnable executes, which is exactly when TTID ends.
+                    rootView.post {
+                        if (!ttidFired.compareAndSet(false, true)) {
+                            // Another Runnable already claimed TTID (shouldn't happen, but be safe).
+                            listener?.let { rootView.viewTreeObserver.removeOnDrawListener(it) }
+                            return@post
+                        }
+
+                        startupSpan?.addEvent(
+                            EVENT_TTID,
+                            Attributes.empty(),
+                            startupClock.now(),
+                            TimeUnit.NANOSECONDS,
+                        )
+                        endSpan()
+                        listener?.let { rootView.viewTreeObserver.removeOnDrawListener(it) }
+                    }
+                }
+                rootView.viewTreeObserver.addOnDrawListener(listener)
+                ttidListenerAttached = true
             }
         }
 
@@ -157,7 +241,19 @@ internal class AppStartupTimer(
         }
     }
 
+    /**
+     * Ends the startup span. If a TTID draw-listener has been attached but hasn't fired yet,
+     * this call is a no-op — the draw listener will end the span at the first committed frame.
+     * This prevents the common mistake of ending the AppStart span at [onActivityResumed],
+     * which fires before the view tree is measured, laid out, and drawn.
+     */
     fun end() {
+        // Yield to the TTID draw listener — it will call endSpan() directly when the frame commits.
+        if (ttidListenerAttached && !ttidFired.get()) return
+        endSpan()
+    }
+
+    private fun endSpan() {
         val overallAppStartSpan = this.startupSpan
         if (overallAppStartSpan != null && !uiInitTooLate) {
             overallAppStartSpan.end(startupClock.now(), TimeUnit.NANOSECONDS)
@@ -191,5 +287,34 @@ internal class AppStartupTimer(
          * Present only when the startup artifact is on the classpath.
          */
         internal const val EVENT_CONTENT_PROVIDER_INIT = "app.init.contentprovider"
+
+        /**
+         * Semantic alias for [EVENT_CONTENT_PROVIDER_INIT] — marks the OS hand-off point
+         * where [android.app.Application.onCreate] is about to run.
+         * Present only when the startup artifact is on the classpath.
+         */
+        internal const val EVENT_APPLICATION_PRE_CREATED = "applicationPreCreated"
+
+        /**
+         * Milestone: OTel SDK initialisation complete; all of [android.app.Application.onCreate]
+         * that ran before the SDK was set up has now been accounted for.
+         */
+        internal const val EVENT_APPLICATION_CREATED = "applicationCreated"
+
+        /**
+         * Milestone: first [android.app.Activity.onActivityPreCreated] fired — the OS hand-off
+         * from [android.app.Application.onCreate] to the first Activity. Emitted only once,
+         * guarded by [AppStartupTimer.postCreatedFired].
+         */
+        internal const val EVENT_APPLICATION_POST_CREATED = "applicationPostCreated"
+
+        /**
+         * Milestone: first frame committed to SurfaceFlinger — the true end of cold-start
+         * TTID (Time to Initial Display). Captured via [ViewTreeObserver.OnDrawListener] on
+         * the first activity's [android.view.Window.decorView], deferred by one looper cycle
+         * via [android.view.View.post] so the timestamp falls after the frame is committed.
+         * This is the timestamp at which the span ends.
+         */
+        internal const val EVENT_TTID = "ttid"
     }
 }

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimerContentProviderEventsTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimerContentProviderEventsTest.kt
@@ -88,6 +88,37 @@ class AppStartupTimerContentProviderEventsTest {
         assertThat(eventNames).doesNotContain(AppStartupTimer.EVENT_CONTENT_PROVIDER_INIT)
     }
 
+    @Test
+    fun `applicationPreCreated event has the same timestamp as app_init_contentprovider`() {
+        val contentProviderMs = System.currentTimeMillis() - 300
+        val provider = fakeProvider(contentProviderEpochMs = contentProviderMs)
+
+        val timer = AppStartupTimer(timestampProvider = provider)
+        timer.start(sdk.getTracer("test"), io.opentelemetry.sdk.common.Clock.getDefault())
+        timer.end()
+
+        val appStart = exporter.finishedSpanItems.single { it.name == RumConstants.APP_START_SPAN_NAME }
+        val contentProviderEvent = appStart.events.first { it.name == AppStartupTimer.EVENT_CONTENT_PROVIDER_INIT }
+        val preCreatedEvent = appStart.events.firstOrNull { it.name == AppStartupTimer.EVENT_APPLICATION_PRE_CREATED }
+
+        assertThat(preCreatedEvent).isNotNull()
+        assertThat(preCreatedEvent!!.epochNanos).isEqualTo(contentProviderEvent.epochNanos)
+    }
+
+    @Test
+    fun `applicationPreCreated event is not emitted when contentProvider timestamp is zero`() {
+        val provider = fakeProvider(contentProviderEpochMs = 0L)
+
+        val timer = AppStartupTimer(timestampProvider = provider)
+        timer.start(sdk.getTracer("test"), io.opentelemetry.sdk.common.Clock.getDefault())
+        timer.end()
+
+        val appStart = exporter.finishedSpanItems.single { it.name == RumConstants.APP_START_SPAN_NAME }
+        val eventNames = appStart.events.map { it.name }
+
+        assertThat(eventNames).doesNotContain(AppStartupTimer.EVENT_APPLICATION_PRE_CREATED)
+    }
+
     private fun fakeProvider(
         attachBaseContextEpochMs: Long = 0L,
         contentProviderEpochMs: Long = 0L,

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimerLifecycleEventsTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimerLifecycleEventsTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.activity.startup
+
+import android.app.Activity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.mockk
+import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.common.Clock
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric tests for [AppStartupTimer.EVENT_APPLICATION_POST_CREATED].
+ *
+ * [android.app.Application.ActivityLifecycleCallbacks.onActivityPreCreated] is an API 29+
+ * default method; the framework won't call it on older SDKs so tests run at sdk=29.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [29])
+class AppStartupTimerLifecycleEventsTest {
+    private lateinit var exporter: InMemorySpanExporter
+    private lateinit var sdk: OpenTelemetrySdk
+
+    @Before
+    fun setUp() {
+        exporter = InMemorySpanExporter.create()
+        sdk =
+            OpenTelemetrySdk
+                .builder()
+                .setTracerProvider(
+                    SdkTracerProvider
+                        .builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                        .build(),
+                ).build()
+    }
+
+    @Test
+    fun `applicationPostCreated event is emitted on first onActivityPreCreated`() {
+        val timer = AppStartupTimer()
+        timer.start(sdk.getTracer("test"), Clock.getDefault())
+
+        val callback = timer.createLifecycleCallback()
+        callback.onActivityPreCreated(mockk<Activity>(relaxed = true), null)
+        timer.end()
+
+        val appStart = exporter.finishedSpanItems.single { it.name == RumConstants.APP_START_SPAN_NAME }
+        val eventNames = appStart.events.map { it.name }
+        assertThat(eventNames).contains(AppStartupTimer.EVENT_APPLICATION_POST_CREATED)
+    }
+
+    @Test
+    fun `applicationPostCreated event is emitted only once even when onActivityPreCreated fires twice`() {
+        val timer = AppStartupTimer()
+        timer.start(sdk.getTracer("test"), Clock.getDefault())
+
+        val callback = timer.createLifecycleCallback()
+        val activity = mockk<Activity>(relaxed = true)
+        // Simulate a second activity (e.g. biometric/splash) firing before the first frame
+        callback.onActivityPreCreated(activity, null)
+        callback.onActivityPreCreated(activity, null)
+        timer.end()
+
+        val appStart = exporter.finishedSpanItems.single { it.name == RumConstants.APP_START_SPAN_NAME }
+        val postCreatedEvents = appStart.events.filter { it.name == AppStartupTimer.EVENT_APPLICATION_POST_CREATED }
+        assertThat(postCreatedEvents).hasSize(1)
+    }
+
+    @Test
+    fun `applicationPostCreated event is not emitted if onActivityPreCreated never fires`() {
+        val timer = AppStartupTimer()
+        timer.start(sdk.getTracer("test"), Clock.getDefault())
+        timer.end()
+
+        val appStart = exporter.finishedSpanItems.single { it.name == RumConstants.APP_START_SPAN_NAME }
+        val eventNames = appStart.events.map { it.name }
+        assertThat(eventNames).doesNotContain(AppStartupTimer.EVENT_APPLICATION_POST_CREATED)
+    }
+}

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimerTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimerTest.kt
@@ -9,6 +9,7 @@ import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertSame
@@ -66,5 +67,15 @@ internal class AppStartupTimerTest {
 
         appStartupTimer.end()
         assertEquals(1, otelTesting.spans.size)
+    }
+
+    @Test
+    fun applicationCreated_event_always_emitted() {
+        val appStartupTimer = AppStartupTimer()
+        appStartupTimer.start(tracer, Clock.getDefault())
+        appStartupTimer.end()
+
+        val eventNames = otelTesting.spans[0].events.map { it.name }
+        assertThat(eventNames).contains(AppStartupTimer.EVENT_APPLICATION_CREATED)
     }
 }

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimerTtidTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimerTtidTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.activity.startup
+
+import android.app.Activity
+import android.view.View
+import android.view.ViewTreeObserver
+import android.view.Window
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.common.Clock
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for TTID (Time to Initial Display) capture in [AppStartupTimer].
+ *
+ * TTID is recorded via [ViewTreeObserver.OnDrawListener] + [View.post] so that the timestamp
+ * falls after the first frame is committed to SurfaceFlinger.
+ *
+ * To avoid dependence on [ViewTreeObserver] internals, the Activity/Window/View chain is
+ * mocked: [View.post] executes the [Runnable] inline (synchronously), which means no looper
+ * draining is needed and tests are straightforward to reason about.
+ *
+ * [FakeActivity] is a local subclass so MockK's ByteBuddy proxy is named in OUR package
+ * (e.g. `...FakeActivity$ByteBuddy$...`) rather than `android.app.Activity$ByteBuddy$...`,
+ * which would otherwise be caught by the system-activity class-name filter in
+ * [AppStartupTimer.createLifecycleCallback].
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [29])
+class AppStartupTimerTtidTest {
+
+    /** Local Activity subclass whose ByteBuddy proxy name will NOT start with "android.". */
+    private class FakeActivity : Activity()
+    private lateinit var exporter: InMemorySpanExporter
+    private lateinit var sdk: OpenTelemetrySdk
+
+    @Before
+    fun setUp() {
+        exporter = InMemorySpanExporter.create()
+        sdk =
+            OpenTelemetrySdk
+                .builder()
+                .setTracerProvider(
+                    SdkTracerProvider
+                        .builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                        .build(),
+                ).build()
+    }
+
+    @Test
+    fun `ttid event is emitted after first frame draw`() {
+        val timer = AppStartupTimer()
+        timer.start(sdk.getTracer("test"), Clock.getDefault())
+
+        val listenerSlot = attachTtidListener(timer)
+        listenerSlot.captured.onDraw()
+
+        val appStart = exporter.finishedSpanItems.single { it.name == RumConstants.APP_START_SPAN_NAME }
+        assertThat(appStart.events.map { it.name }).contains(AppStartupTimer.EVENT_TTID)
+    }
+
+    @Test
+    fun `span ends when ttid fires`() {
+        val timer = AppStartupTimer()
+        timer.start(sdk.getTracer("test"), Clock.getDefault())
+
+        val listenerSlot = attachTtidListener(timer)
+        listenerSlot.captured.onDraw()
+
+        assertThat(exporter.finishedSpanItems).hasSize(1)
+    }
+
+    @Test
+    fun `end is no-op while ttid listener is attached but not yet fired`() {
+        val timer = AppStartupTimer()
+        timer.start(sdk.getTracer("test"), Clock.getDefault())
+
+        attachTtidListener(timer)  // attaches listener but does not fire onDraw()
+
+        // draw listener has been attached; end() must yield to it
+        timer.end()
+
+        assertThat(exporter.finishedSpanItems).isEmpty()
+    }
+
+    @Test
+    fun `ttid event is emitted only once even if draw fires multiple times`() {
+        val timer = AppStartupTimer()
+        timer.start(sdk.getTracer("test"), Clock.getDefault())
+
+        val listenerSlot = attachTtidListener(timer)
+        listenerSlot.captured.onDraw()
+        // second call — AtomicBoolean guard in the posted Runnable prevents a duplicate
+        listenerSlot.captured.onDraw()
+
+        val appStart = exporter.finishedSpanItems.single { it.name == RumConstants.APP_START_SPAN_NAME }
+        assertThat(appStart.events.filter { it.name == AppStartupTimer.EVENT_TTID }).hasSize(1)
+    }
+
+    @Test
+    fun `without ttid listener end ends the span normally`() {
+        val timer = AppStartupTimer()
+        timer.start(sdk.getTracer("test"), Clock.getDefault())
+
+        // No onActivityResumed → no draw listener → end() ends the span immediately
+        timer.end()
+
+        assertThat(exporter.finishedSpanItems).hasSize(1)
+        assertThat(exporter.finishedSpanItems[0].name).isEqualTo(RumConstants.APP_START_SPAN_NAME)
+    }
+
+    @Test
+    fun `onActivityResumed after span is cleared is a no-op`() {
+        val timer = AppStartupTimer()
+        timer.start(sdk.getTracer("test"), Clock.getDefault())
+        timer.end()  // clears startupSpan
+
+        // startupSpan is null → onActivityResumed returns immediately, must not throw
+        val activity = mockk<FakeActivity>(relaxed = true)
+        timer.createLifecycleCallback().onActivityResumed(activity)
+
+        assertThat(exporter.finishedSpanItems).hasSize(1)
+    }
+
+    /**
+     * Calls [AppStartupTimer.createLifecycleCallback].onActivityResumed() with a mocked
+     * Activity/Window/View chain. [View.post] is stubbed to execute the [Runnable] inline
+     * (synchronously) so no looper draining is needed.
+     *
+     * @return the [CapturingSlot] holding the [ViewTreeObserver.OnDrawListener] registered by
+     *   [AppStartupTimer]; call [ViewTreeObserver.OnDrawListener.onDraw] on it to simulate a draw.
+     */
+    private fun attachTtidListener(timer: AppStartupTimer): CapturingSlot<ViewTreeObserver.OnDrawListener> {
+        val listenerSlot = slot<ViewTreeObserver.OnDrawListener>()
+        val vto =
+            mockk<ViewTreeObserver>(relaxed = true) {
+                every { addOnDrawListener(capture(listenerSlot)) } just runs
+            }
+        val decorView =
+            mockk<View>(relaxed = true) {
+                every { viewTreeObserver } returns vto
+                // Run the Runnable inline — no looper needed
+                every { post(any()) } answers { firstArg<Runnable>().run(); true }
+            }
+        val window =
+            mockk<Window>(relaxed = true) {
+                every { this@mockk.decorView } returns decorView
+            }
+        val activity =
+            mockk<FakeActivity>(relaxed = true) {
+                every { this@mockk.window } returns window
+            }
+        timer.createLifecycleCallback().onActivityResumed(activity)
+        return listenerSlot
+    }
+}


### PR DESCRIPTION
Milestone events added to the AppStart span:
- applicationPreCreated: alias of app.init.contentprovider, marks OS hand-off to Application.onCreate()
- applicationCreated: emitted at end of AppStartupTimer.start(), marks OTel SDK init complete
- applicationPostCreated: first onActivityPreCreated, guarded by AtomicBoolean to fire only once (handles BFSI apps with early secondary activities)
- ttid: first frame committed to SurfaceFlinger, captured via ViewTreeObserver.OnDrawListener on decorView + View.post() deferral; this is the true TTID end — not onResume()

AppStartupTimer.end() now yields to the draw listener when it is attached but has not yet fired, preventing the span from being closed before the first frame.

Tests:
- AppStartupTimerTest: applicationCreated always emitted (JUnit5)
- AppStartupTimerContentProviderEventsTest: applicationPreCreated timestamp matches app.init.contentprovider; not emitted when contentProvider ts is 0
- AppStartupTimerLifecycleEventsTest: applicationPostCreated emitted once; AtomicBoolean guard prevents duplicate on second onActivityPreCreated
- AppStartupTimerTtidTest: full TTID coverage — event emitted, span ends, end() no-op guard, once-only guard, null-span safety