### PR TITLE
feat(session): add SessionProvider.endSession for immediate session rotation

### DIFF
--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionManager.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionManager.kt
@@ -40,27 +40,35 @@ internal class SessionManager(
 
         // Check if we need to create a new session.
         return if (sessionHasExpired(currentSession) || timeoutHandler.hasTimedOut()) {
-            val newId = idGenerator.generateSessionId()
-            val newSession = SessionImpl(newId, clock.now())
-
-            // Atomically update the session only if it hasn't been changed by another thread.
-            if (session.compareAndSet(currentSession, newSession)) {
-                sessionStorage.save(newSession)
-                timeoutHandler.bump()
-                // Observers need to be called after bumping the timer because it may create a new
-                // span.
-                notifyObserversOfSessionUpdate(currentSession, newSession)
-                newSession.id
-            } else {
-                // Another thread accessed this function prior to creating a new session. Use the
-                // current session.
-                timeoutHandler.bump()
-                session.get().id
-            }
+            rotateSession(currentSession)
         } else {
             // No new session needed, just bump the timeout and return current session ID
             timeoutHandler.bump()
             currentSession.id
+        }
+    }
+
+    override fun endSession() {
+        rotateSession(session.get())
+    }
+
+    private fun rotateSession(currentSession: Session): String {
+        val newId = idGenerator.generateSessionId()
+        val newSession = SessionImpl(newId, clock.now())
+
+        // Atomically update the session only if it hasn't been changed by another thread.
+        return if (session.compareAndSet(currentSession, newSession)) {
+            sessionStorage.save(newSession)
+            timeoutHandler.bump()
+            // Observers need to be called after bumping the timer because it may create a new
+            // span.
+            notifyObserversOfSessionUpdate(currentSession, newSession)
+            newSession.id
+        } else {
+            // Another thread accessed this function prior to creating a new session. Use the
+            // current session.
+            timeoutHandler.bump()
+            session.get().id
         }
     }
 

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionManagerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionManagerTest.kt
@@ -309,6 +309,66 @@ internal class SessionManagerTest {
     }
 
     @Test
+    fun `endSession rotates to a new session id immediately`() {
+        val clock = TestClock.create()
+        val sessionManager =
+            SessionManager(
+                clock,
+                timeoutHandler = timeoutHandler,
+                maxSessionLifetime = MAX_SESSION_LIFETIME.hours,
+            )
+        val firstSessionId = sessionManager.getSessionId()
+
+        sessionManager.endSession()
+        val secondSessionId = sessionManager.getSessionId()
+
+        assertThat(secondSessionId).isNotEqualTo(firstSessionId)
+        assertThat(secondSessionId).hasSize(SESSION_ID_LENGTH)
+    }
+
+    @Test
+    fun `endSession notifies observers of session end and start`() {
+        val clock = TestClock.create()
+        val observer = mockk<SessionObserver>()
+        every { observer.onSessionStarted(any<Session>(), any<Session>()) } just Runs
+        every { observer.onSessionEnded(any<Session>()) } just Runs
+
+        val sessionManager =
+            SessionManager(
+                clock,
+                timeoutHandler = timeoutHandler,
+                maxSessionLifetime = MAX_SESSION_LIFETIME.hours,
+            )
+        sessionManager.addObserver(observer)
+        val firstSessionId = sessionManager.getSessionId()
+
+        sessionManager.endSession()
+
+        verify {
+            observer.onSessionEnded(match { it.id == firstSessionId })
+            observer.onSessionStarted(match { it.id != firstSessionId }, match { it.id == firstSessionId })
+        }
+    }
+
+    @Test
+    fun `consecutive endSession calls yield distinct session ids`() {
+        val sessionManager =
+            SessionManager(
+                TestClock.create(),
+                timeoutHandler = timeoutHandler,
+                maxSessionLifetime = MAX_SESSION_LIFETIME.hours,
+            )
+        sessionManager.getSessionId()
+
+        sessionManager.endSession()
+        val firstRotation = sessionManager.getSessionId()
+        sessionManager.endSession()
+        val secondRotation = sessionManager.getSessionId()
+
+        assertThat(firstRotation).isNotEqualTo(secondRotation)
+    }
+
+    @Test
     fun `session expiration check uses correct session instance`() {
         // Given
         val clock = TestClock.create()

--- a/session/src/main/kotlin/io/opentelemetry/android/session/SessionProvider.kt
+++ b/session/src/main/kotlin/io/opentelemetry/android/session/SessionProvider.kt
@@ -15,6 +15,14 @@ fun interface SessionProvider {
      */
     fun getSessionId(): String
 
+    /**
+     * Ends the current session immediately and starts a new one with a fresh session ID.
+     * Default implementation is a no-op for custom providers that do not support rotation.
+     */
+    fun endSession() {
+        // default noop
+    }
+
     companion object {
 
         /**


### PR DESCRIPTION
## Summary
- Add `SessionProvider.endSession()` with a default no-op for custom providers.
- Implement immediate session rotation in `SessionManager` by extracting shared `rotateSession` logic used by expiry and explicit end.
- Notify `SessionObserver` callbacks on manual session end so SDK layers can clear session-scoped state.

Required by vunetsystems/vuTelemetry-android session API (`Vunet.endSession()`).

## Test plan
- [x] `./gradlew :android-agent:testDebugUnitTest`
- [ ] Verify consecutive `endSession()` calls produce distinct session IDs in a running app