### PR TITLE
feat: add RumDiagnostics verbose logging across the RUM stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ demo-app/local.properties
 .DS_Store
 **/build/
 .kotlin/
+.vscode/

--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -59,6 +59,7 @@ public final class io/opentelemetry/android/agent/dsl/HttpExportConfiguration {
 public final class io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration {
 	public final fun diskBuffering (Lkotlin/jvm/functions/Function1;)V
 	public final fun getClock ()Lio/opentelemetry/sdk/common/Clock;
+	public final fun getDiagnosticLogging ()Z
 	public final fun globalAttributes (Lkotlin/jvm/functions/Function0;)V
 	public final fun globalAttributesSupplier (Lkotlin/jvm/functions/Function0;)V
 	public final fun httpExport (Lkotlin/jvm/functions/Function1;)V
@@ -66,6 +67,7 @@ public final class io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration
 	public final fun resource (Lkotlin/jvm/functions/Function1;)V
 	public final fun session (Lkotlin/jvm/functions/Function1;)V
 	public final fun setClock (Lio/opentelemetry/sdk/common/Clock;)V
+	public final fun setDiagnosticLogging (Z)V
 }
 
 public final class io/opentelemetry/android/agent/dsl/SessionConfiguration {

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -14,6 +14,10 @@ import io.opentelemetry.android.RumBuilder
 import io.opentelemetry.android.agent.connectivity.Compression
 import io.opentelemetry.android.agent.connectivity.HttpEndpointConnectivity
 import io.opentelemetry.android.agent.dsl.OpenTelemetryConfiguration
+import io.opentelemetry.android.agent.export.LoggingLogRecordExporterDecorator
+import io.opentelemetry.android.agent.export.LoggingMetricExporterDecorator
+import io.opentelemetry.android.agent.export.LoggingSpanExporterDecorator
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.agent.session.SessionConfig
 import io.opentelemetry.android.agent.session.SessionIdTimeoutHandler
 import io.opentelemetry.android.agent.session.SessionManager
@@ -54,6 +58,7 @@ object OpenTelemetryRumInitializer {
         val builder = RumBuilder.builder(ctx, rumConfig)
         val cfg = OpenTelemetryConfiguration(rumConfig, instrumentationLoader = builder.instrumentationLoader)
         configuration(cfg)
+        RumDiagnostics.verbose = cfg.diagnosticLogging
 
         val spansEndpoint = cfg.exportConfig.spansEndpoint()
         val logsEndpoints = cfg.exportConfig.logsEndpoint()
@@ -67,10 +72,40 @@ object OpenTelemetryRumInitializer {
             .setSessionProvider(createSessionProvider(ctx, cfg))
             .setResource(resource)
             .setClock(cfg.clock)
-            .addSpanExporterCustomizer { createSpanExporter(spansEndpoint) }
-            .addLogRecordExporterCustomizer { createLogExporter(logsEndpoints) }
-            .addMetricExporterCustomizer { createMetricExporter(metricsEndpoint) }
+            .addSpanExporterCustomizer { wrapSpanExporter(createSpanExporter(spansEndpoint), spansEndpoint, cfg.diagnosticLogging) }
+            .addLogRecordExporterCustomizer { wrapLogExporter(createLogExporter(logsEndpoints), logsEndpoints, cfg.diagnosticLogging) }
+            .addMetricExporterCustomizer { wrapMetricExporter(createMetricExporter(metricsEndpoint), metricsEndpoint, cfg.diagnosticLogging) }
             .build()
+    }
+
+    private fun wrapSpanExporter(
+        exporter: OtlpHttpSpanExporter,
+        endpoint: HttpEndpointConnectivity,
+        diagnosticLogging: Boolean,
+    ) = if (diagnosticLogging) {
+        LoggingSpanExporterDecorator(exporter, endpoint.getUrl())
+    } else {
+        exporter
+    }
+
+    private fun wrapLogExporter(
+        exporter: OtlpHttpLogRecordExporter,
+        endpoint: HttpEndpointConnectivity,
+        diagnosticLogging: Boolean,
+    ) = if (diagnosticLogging) {
+        LoggingLogRecordExporterDecorator(exporter, endpoint.getUrl())
+    } else {
+        exporter
+    }
+
+    private fun wrapMetricExporter(
+        exporter: OtlpHttpMetricExporter,
+        endpoint: HttpEndpointConnectivity,
+        diagnosticLogging: Boolean,
+    ) = if (diagnosticLogging) {
+        LoggingMetricExporterDecorator(exporter, endpoint.getUrl())
+    } else {
+        exporter
     }
 
     private fun createSpanExporter(endpoint: HttpEndpointConnectivity): OtlpHttpSpanExporter =

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -74,7 +74,9 @@ object OpenTelemetryRumInitializer {
             .setClock(cfg.clock)
             .addSpanExporterCustomizer { wrapSpanExporter(createSpanExporter(spansEndpoint), spansEndpoint, cfg.diagnosticLogging) }
             .addLogRecordExporterCustomizer { wrapLogExporter(createLogExporter(logsEndpoints), logsEndpoints, cfg.diagnosticLogging) }
-            .addMetricExporterCustomizer { wrapMetricExporter(createMetricExporter(metricsEndpoint), metricsEndpoint, cfg.diagnosticLogging) }
+            .addMetricExporterCustomizer {
+                wrapMetricExporter(createMetricExporter(metricsEndpoint), metricsEndpoint, cfg.diagnosticLogging)
+            }
             .build()
     }
 

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
@@ -34,6 +34,11 @@ class OpenTelemetryConfiguration internal constructor(
     internal var resourceAction: ResourceBuilder.() -> Unit = {}
 
     /**
+     * When true, enables verbose diagnostics across instrumentations and OTLP export decorators.
+     */
+    var diagnosticLogging: Boolean = false
+
+    /**
      * Configures how OpenTelemetry should export telemetry over HTTP.
      */
     fun httpExport(action: HttpExportConfiguration.() -> Unit) {

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/export/ExportDiagnosticsFormatter.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/export/ExportDiagnosticsFormatter.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.export
+
+import io.opentelemetry.android.common.RumDiagnostics
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.logs.data.LogRecordData
+import io.opentelemetry.sdk.metrics.data.MetricData
+import io.opentelemetry.sdk.trace.data.SpanData
+
+internal object ExportDiagnosticsFormatter {
+    const val MAX_ITEMS: Int = 5
+
+    fun formatSpan(span: SpanData): String = "span item=${span.name}"
+
+    fun formatLog(log: LogRecordData): String {
+        val eventName = log.eventName?.takeIf { it.isNotEmpty() } ?: "log"
+        return "log item=$eventName"
+    }
+
+    fun formatMetric(metric: MetricData): String = "metric item=${metric.name}"
+
+    fun <T> logItems(
+        signal: String,
+        items: Collection<T>,
+        formatter: (T) -> String,
+    ) {
+        if (items.isEmpty()) {
+            return
+        }
+        items.take(MAX_ITEMS).forEach { item ->
+            RumDiagnostics.d { "export $signal: ${formatter(item)}" }
+        }
+        val remaining = items.size - MAX_ITEMS
+        if (remaining > 0) {
+            RumDiagnostics.d { "export $signal: +$remaining more" }
+        }
+    }
+
+    fun logExportOutcome(
+        signal: String,
+        count: Int,
+        endpoint: String,
+        result: CompletableResultCode,
+    ) {
+        result.whenComplete {
+            if (result.isSuccess) {
+                RumDiagnostics.d { "export $signal: success count=$count endpoint=$endpoint" }
+            } else {
+                val throwable = result.failureThrowable
+                val reason = throwable?.message ?: "unknown"
+                if (throwable != null) {
+                    RumDiagnostics.w(
+                        { "export $signal: failure count=$count endpoint=$endpoint reason=$reason" },
+                        throwable,
+                    )
+                } else {
+                    RumDiagnostics.w { "export $signal: failure count=$count endpoint=$endpoint reason=$reason" }
+                }
+            }
+        }
+    }
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/export/LoggingLogRecordExporterDecorator.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/export/LoggingLogRecordExporterDecorator.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.export
+
+import io.opentelemetry.android.common.RumDiagnostics
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.logs.data.LogRecordData
+import io.opentelemetry.sdk.logs.export.LogRecordExporter
+
+internal class LoggingLogRecordExporterDecorator(
+    private val delegate: LogRecordExporter,
+    private val endpoint: String,
+) : LogRecordExporter by delegate {
+
+    override fun export(logs: Collection<LogRecordData>): CompletableResultCode {
+        RumDiagnostics.d { "export logs: count=${logs.size} endpoint=$endpoint" }
+        ExportDiagnosticsFormatter.logItems("logs", logs, ExportDiagnosticsFormatter::formatLog)
+        val result = delegate.export(logs)
+        ExportDiagnosticsFormatter.logExportOutcome("logs", logs.size, endpoint, result)
+        return result
+    }
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/export/LoggingMetricExporterDecorator.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/export/LoggingMetricExporterDecorator.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.export
+
+import io.opentelemetry.android.common.RumDiagnostics
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.metrics.InstrumentType
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality
+import io.opentelemetry.sdk.metrics.data.MetricData
+import io.opentelemetry.sdk.metrics.export.MetricExporter
+
+internal class LoggingMetricExporterDecorator(
+    private val delegate: MetricExporter,
+    private val endpoint: String,
+) : MetricExporter by delegate {
+
+    override fun export(metrics: Collection<MetricData>): CompletableResultCode {
+        RumDiagnostics.d { "export metrics: count=${metrics.size} endpoint=$endpoint" }
+        ExportDiagnosticsFormatter.logItems("metrics", metrics, ExportDiagnosticsFormatter::formatMetric)
+        val result = delegate.export(metrics)
+        ExportDiagnosticsFormatter.logExportOutcome("metrics", metrics.size, endpoint, result)
+        return result
+    }
+
+    override fun getAggregationTemporality(instrumentType: InstrumentType): AggregationTemporality =
+        delegate.getAggregationTemporality(instrumentType)
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/export/LoggingSpanExporterDecorator.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/export/LoggingSpanExporterDecorator.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.export
+
+import io.opentelemetry.android.common.RumDiagnostics
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.sdk.trace.export.SpanExporter
+
+internal class LoggingSpanExporterDecorator(
+    private val delegate: SpanExporter,
+    private val endpoint: String,
+) : SpanExporter by delegate {
+
+    override fun export(spans: Collection<SpanData>): CompletableResultCode {
+        RumDiagnostics.d { "export spans: count=${spans.size} endpoint=$endpoint" }
+        ExportDiagnosticsFormatter.logItems("spans", spans, ExportDiagnosticsFormatter::formatSpan)
+        val result = delegate.export(spans)
+        ExportDiagnosticsFormatter.logExportOutcome("spans", spans.size, endpoint, result)
+        return result
+    }
+}

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/DiagnosticLoggingConfigTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/DiagnosticLoggingConfigTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl
+
+import io.opentelemetry.android.Incubating
+import io.opentelemetry.android.agent.OpenTelemetryRumInitializer
+import io.opentelemetry.android.common.RumDiagnostics
+import io.opentelemetry.android.agent.FakeInstrumentationLoader
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@OptIn(Incubating::class)
+@RunWith(RobolectricTestRunner::class)
+class DiagnosticLoggingConfigTest {
+    @After
+    fun tearDown() {
+        RumDiagnostics.verbose = false
+    }
+
+    @Test
+    fun diagnosticLogging_defaultsToFalse() {
+        val cfg = OpenTelemetryConfiguration(instrumentationLoader = FakeInstrumentationLoader())
+        assertFalse(cfg.diagnosticLogging)
+    }
+
+    @Test
+    fun diagnosticLogging_enablesRumDiagnosticsDuringInitialize() {
+        val rum =
+            OpenTelemetryRumInitializer.initialize(
+                context = RuntimeEnvironment.getApplication(),
+                configuration = {
+                    diagnosticLogging = true
+                    httpExport {
+                        baseUrl = "http://127.0.0.1:4318"
+                    }
+                },
+            )
+        try {
+            assertTrue(RumDiagnostics.verbose)
+        } finally {
+            rum.shutdown()
+            RumDiagnostics.verbose = false
+        }
+    }
+}

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/export/ExportDiagnosticsFormatterTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/export/ExportDiagnosticsFormatterTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.export
+
+import io.mockk.every
+import io.mockk.mockk
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.sdk.metrics.data.MetricData
+import io.opentelemetry.sdk.logs.data.LogRecordData
+import io.opentelemetry.sdk.testing.trace.TestSpanData
+import io.opentelemetry.sdk.trace.data.StatusData
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class ExportDiagnosticsFormatterTest {
+    @Test
+    fun formatSpan_includesNameOnly() {
+        val span =
+            TestSpanData
+                .builder()
+                .setName("ui.click")
+                .setKind(SpanKind.INTERNAL)
+                .setStatus(StatusData.unset())
+                .setHasEnded(true)
+                .setStartEpochNanos(0)
+                .setEndEpochNanos(1)
+                .build()
+
+        val formatted = ExportDiagnosticsFormatter.formatSpan(span)
+
+        assertEquals("span item=ui.click", formatted)
+        assertFalse(formatted.contains("attrs"))
+    }
+
+    @Test
+    fun formatLog_includesEventNameOnly() {
+        val log = mockk<LogRecordData>()
+        every { log.eventName } returns "session.start"
+
+        assertEquals("log item=session.start", ExportDiagnosticsFormatter.formatLog(log))
+    }
+
+    @Test
+    fun formatLog_usesFallbackWhenEventNameMissing() {
+        val log = mockk<LogRecordData>()
+        every { log.eventName } returns null
+
+        assertEquals("log item=log", ExportDiagnosticsFormatter.formatLog(log))
+    }
+
+    @Test
+    fun formatMetric_includesNameOnly() {
+        val metric = mockk<MetricData>()
+        every { metric.name } returns "process.cpu.usage"
+
+        assertEquals("metric item=process.cpu.usage", ExportDiagnosticsFormatter.formatMetric(metric))
+    }
+}

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/export/LoggingLogRecordExporterDecoratorTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/export/LoggingLogRecordExporterDecoratorTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.export
+
+import android.util.Log
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.common.RumDiagnostics
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.logs.data.LogRecordData
+import io.opentelemetry.sdk.logs.export.LogRecordExporter
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LoggingLogRecordExporterDecoratorTest {
+    private val delegate: LogRecordExporter = mockk()
+    private val endpoint = "http://127.0.0.1:4318/v1/logs"
+
+    @Before
+    fun setUp() {
+        RumDiagnostics.verbose = true
+        mockkStatic(Log::class)
+        every { Log.d(any(), any<String>()) } returns 0
+        every { Log.w(any(), any<String>()) } returns 0
+        every { Log.w(any(), any<String>(), any()) } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        RumDiagnostics.verbose = false
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun export_logsSuccessWithEndpointAndItemName() {
+        val log = mockk<LogRecordData>()
+        every { log.eventName } returns "session.start"
+        val logs = listOf(log)
+        val result = CompletableResultCode.ofSuccess()
+        every { delegate.export(logs) } returns result
+
+        LoggingLogRecordExporterDecorator(delegate, endpoint).export(logs)
+
+        verify {
+            Log.d(RumConstants.OTEL_RUM_LOG_TAG, "export logs: success count=1 endpoint=$endpoint")
+        }
+        verify {
+            Log.d(RumConstants.OTEL_RUM_LOG_TAG, "export logs: log item=session.start")
+        }
+    }
+
+    @Test
+    fun export_logsFailureWithReason() {
+        val logs = emptyList<LogRecordData>()
+        val error = RuntimeException("connection refused")
+        val result = CompletableResultCode.ofExceptionalFailure(error)
+        every { delegate.export(logs) } returns result
+
+        LoggingLogRecordExporterDecorator(delegate, endpoint)
+            .export(logs)
+            .join(1, java.util.concurrent.TimeUnit.SECONDS)
+
+        verify {
+            Log.w(
+                RumConstants.OTEL_RUM_LOG_TAG,
+                "export logs: failure count=0 endpoint=$endpoint reason=connection refused",
+                error,
+            )
+        }
+    }
+}

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/export/LoggingMetricExporterDecoratorTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/export/LoggingMetricExporterDecoratorTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.export
+
+import android.util.Log
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.common.RumDiagnostics
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.metrics.InstrumentType
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality
+import io.opentelemetry.sdk.metrics.data.MetricData
+import io.opentelemetry.sdk.metrics.export.MetricExporter
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LoggingMetricExporterDecoratorTest {
+    private val delegate: MetricExporter = mockk()
+    private val endpoint = "http://127.0.0.1:4318/v1/metrics"
+
+    @Before
+    fun setUp() {
+        RumDiagnostics.verbose = true
+        mockkStatic(Log::class)
+        every { Log.d(any(), any<String>()) } returns 0
+        every { Log.w(any(), any<String>()) } returns 0
+        every { Log.w(any(), any<String>(), any()) } returns 0
+        every { delegate.getAggregationTemporality(any()) } returns AggregationTemporality.CUMULATIVE
+    }
+
+    @After
+    fun tearDown() {
+        RumDiagnostics.verbose = false
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun export_logsSuccessWithEndpointAndItemName() {
+        val metric = mockk<MetricData>()
+        every { metric.name } returns "process.cpu.usage"
+        val metrics = listOf(metric)
+        val result = CompletableResultCode.ofSuccess()
+        every { delegate.export(metrics) } returns result
+
+        LoggingMetricExporterDecorator(delegate, endpoint).export(metrics)
+
+        verify {
+            Log.d(RumConstants.OTEL_RUM_LOG_TAG, "export metrics: success count=1 endpoint=$endpoint")
+        }
+        verify {
+            Log.d(RumConstants.OTEL_RUM_LOG_TAG, "export metrics: metric item=process.cpu.usage")
+        }
+    }
+
+    @Test
+    fun export_logsFailureWithReason() {
+        val metrics = emptyList<MetricData>()
+        val error = RuntimeException("timeout")
+        val result = CompletableResultCode.ofExceptionalFailure(error)
+        every { delegate.export(metrics) } returns result
+
+        LoggingMetricExporterDecorator(delegate, endpoint)
+            .export(metrics)
+            .join(1, java.util.concurrent.TimeUnit.SECONDS)
+
+        verify {
+            Log.w(
+                RumConstants.OTEL_RUM_LOG_TAG,
+                "export metrics: failure count=0 endpoint=$endpoint reason=timeout",
+                error,
+            )
+        }
+    }
+}

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/export/LoggingMetricExporterDecoratorTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/export/LoggingMetricExporterDecoratorTest.kt
@@ -14,7 +14,6 @@ import io.mockk.verify
 import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.sdk.common.CompletableResultCode
-import io.opentelemetry.sdk.metrics.InstrumentType
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality
 import io.opentelemetry.sdk.metrics.data.MetricData
 import io.opentelemetry.sdk.metrics.export.MetricExporter

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/export/LoggingSpanExporterDecoratorTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/export/LoggingSpanExporterDecoratorTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.export
+
+import android.util.Log
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.common.RumDiagnostics
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.testing.trace.TestSpanData
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.sdk.trace.data.StatusData
+import io.opentelemetry.sdk.trace.export.SpanExporter
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LoggingSpanExporterDecoratorTest {
+    private val delegate: SpanExporter = mockk()
+    private val endpoint = "http://127.0.0.1:4318/v1/traces"
+
+    @Before
+    fun setUp() {
+        RumDiagnostics.verbose = true
+        mockkStatic(Log::class)
+        every { Log.d(any(), any<String>()) } returns 0
+        every { Log.w(any(), any<String>()) } returns 0
+        every { Log.w(any(), any<String>(), any()) } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        RumDiagnostics.verbose = false
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun export_delegatesAndLogsSuccessWithEndpoint() {
+        val spans = listOf(testSpan("ui.click"))
+        val result = CompletableResultCode.ofSuccess()
+        every { delegate.export(spans) } returns result
+
+        val decorator = LoggingSpanExporterDecorator(delegate, endpoint)
+        val exportResult = decorator.export(spans)
+
+        verify { delegate.export(spans) }
+        assert(exportResult.isSuccess)
+        verify {
+            Log.d(RumConstants.OTEL_RUM_LOG_TAG, "export spans: success count=1 endpoint=$endpoint")
+        }
+        verify {
+            Log.d(RumConstants.OTEL_RUM_LOG_TAG, "export spans: span item=ui.click")
+        }
+    }
+
+    @Test
+    fun export_delegatesAndLogsFailureWithReason() {
+        val spans = emptyList<SpanData>()
+        val error = RuntimeException("connection reset")
+        val result = CompletableResultCode.ofExceptionalFailure(error)
+        every { delegate.export(spans) } returns result
+
+        val decorator = LoggingSpanExporterDecorator(delegate, endpoint)
+        decorator.export(spans).join(1, java.util.concurrent.TimeUnit.SECONDS)
+
+        verify { delegate.export(spans) }
+        verify {
+            Log.w(
+                RumConstants.OTEL_RUM_LOG_TAG,
+                "export spans: failure count=0 endpoint=$endpoint reason=connection reset",
+                error,
+            )
+        }
+    }
+
+    private fun testSpan(name: String): SpanData =
+        TestSpanData
+            .builder()
+            .setName(name)
+            .setKind(SpanKind.INTERNAL)
+            .setStatus(StatusData.unset())
+            .setHasEnded(true)
+            .setStartEpochNanos(0)
+            .setEndEpochNanos(1)
+            .build()
+}

--- a/common/api/common.api
+++ b/common/api/common.api
@@ -28,6 +28,16 @@ public final class io/opentelemetry/android/common/RumConstants$Events {
 	public static final field INSTANCE Lio/opentelemetry/android/common/RumConstants$Events;
 }
 
+public final class io/opentelemetry/android/common/RumDiagnostics {
+	public static final field INSTANCE Lio/opentelemetry/android/common/RumDiagnostics;
+	public final fun d (Lkotlin/jvm/functions/Function0;)V
+	public final fun getVerbose ()Z
+	public final fun i (Lkotlin/jvm/functions/Function0;)V
+	public final fun setVerbose (Z)V
+	public final fun w (Lkotlin/jvm/functions/Function0;)V
+	public final fun w (Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;)V
+}
+
 public abstract interface class io/opentelemetry/android/common/StartupTimestampProvider {
 	public abstract fun getAttachBaseContextEndElapsedRealtime ()J
 	public abstract fun getAttachBaseContextStartElapsedRealtime ()J

--- a/common/src/main/java/io/opentelemetry/android/common/RumConstants.kt
+++ b/common/src/main/java/io/opentelemetry/android/common/RumConstants.kt
@@ -8,7 +8,7 @@ package io.opentelemetry.android.common
 import io.opentelemetry.api.common.AttributeKey
 
 object RumConstants {
-    const val OTEL_RUM_LOG_TAG: String = "OpenTelemetryRum"
+    const val OTEL_RUM_LOG_TAG: String = "VuNetRUM"
 
     @JvmField
     val LAST_SCREEN_NAME_KEY: AttributeKey<String> = AttributeKey.stringKey("last.screen.name")

--- a/common/src/main/java/io/opentelemetry/android/common/RumDiagnostics.kt
+++ b/common/src/main/java/io/opentelemetry/android/common/RumDiagnostics.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.common
+
+import android.util.Log
+
+/**
+ * Global verbose diagnostics for the OpenTelemetry Android RUM stack.
+ * Enabled via [verbose] during agent initialization when diagnostic logging is on.
+ */
+object RumDiagnostics {
+
+    @Volatile
+    var verbose: Boolean = false
+
+    inline fun d(message: () -> String) {
+        if (verbose) {
+            Log.d(RumConstants.OTEL_RUM_LOG_TAG, message())
+        }
+    }
+
+    inline fun i(message: () -> String) {
+        if (verbose) {
+            Log.i(RumConstants.OTEL_RUM_LOG_TAG, message())
+        }
+    }
+
+    inline fun w(message: () -> String) {
+        if (verbose) {
+            Log.w(RumConstants.OTEL_RUM_LOG_TAG, message())
+        }
+    }
+
+    inline fun w(
+        message: () -> String,
+        throwable: Throwable,
+    ) {
+        if (verbose) {
+            Log.w(RumConstants.OTEL_RUM_LOG_TAG, message(), throwable)
+        }
+    }
+}

--- a/common/src/test/java/io/opentelemetry/android/common/RumConstantsTest.kt
+++ b/common/src/test/java/io/opentelemetry/android/common/RumConstantsTest.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RumConstantsTest {
+    @Test
+    fun otelRumLogTag_isVuNetBranded() {
+        assertEquals("VuNetRUM", RumConstants.OTEL_RUM_LOG_TAG)
+    }
+}

--- a/common/src/test/java/io/opentelemetry/android/common/RumDiagnosticsTest.kt
+++ b/common/src/test/java/io/opentelemetry/android/common/RumDiagnosticsTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.common
+
+import android.util.Log
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RumDiagnosticsTest {
+    @Before
+    fun setUp() {
+        RumDiagnostics.verbose = false
+        mockkStatic(Log::class)
+        every { Log.d(any(), any<String>()) } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        RumDiagnostics.verbose = false
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun d_doesNotLogWhenVerboseDisabled() {
+        RumDiagnostics.d { "should not appear" }
+        verify(exactly = 0) { Log.d(any(), any<String>()) }
+    }
+
+    @Test
+    fun d_logsWhenVerboseEnabled() {
+        RumDiagnostics.verbose = true
+        RumDiagnostics.d { "diagnostic line" }
+        verify(exactly = 1) { Log.d(RumConstants.OTEL_RUM_LOG_TAG, "diagnostic line") }
+    }
+}

--- a/core/src/main/java/io/opentelemetry/android/export/DelegatingExporter.kt
+++ b/core/src/main/java/io/opentelemetry/android/export/DelegatingExporter.kt
@@ -5,8 +5,7 @@
 
 package io.opentelemetry.android.export
 
-import android.util.Log
-import io.opentelemetry.android.common.RumConstants.OTEL_RUM_LOG_TAG
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.api.internal.GuardedBy
 import io.opentelemetry.sdk.common.CompletableResultCode
 import java.nio.BufferOverflowException
@@ -93,8 +92,8 @@ internal class DelegatingExporter<D, T>(
                 val amountToTake = maxBufferedData - buffer.size
                 buffer.addAll(data.take(amountToTake))
                 if (amountToTake < data.size) {
-                    Log.w(OTEL_RUM_LOG_TAG, "The $logType buffer was filled before export delegate set...")
-                    Log.w(OTEL_RUM_LOG_TAG, "This has resulted in a loss of $logType!")
+                    RumDiagnostics.w { "diskBuffer: $logType buffer filled before delegate set" }
+                    RumDiagnostics.w { "diskBuffer: loss of $logType" }
                 }
 
                 // If all the data was dropped we return an exception

--- a/core/src/main/java/io/opentelemetry/android/internal/features/persistence/DiskManager.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/features/persistence/DiskManager.kt
@@ -5,8 +5,7 @@
 
 package io.opentelemetry.android.internal.features.persistence
 
-import android.util.Log
-import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig
 import io.opentelemetry.android.internal.services.storage.CacheStorage
 import java.io.File
@@ -45,7 +44,7 @@ internal class DiskManager(
 
             // Divides the available cache size by 3 (for each signal's folder)
             val calculatedSize = requestedSize / 3
-            Log.d(RumConstants.OTEL_RUM_LOG_TAG, "Requested cache size: %s, folder size: $requestedSize")
+            RumDiagnostics.d { "diskBuffer: requestedCacheSize=$requestedSize folderSize=$calculatedSize" }
             return calculatedSize
         }
 

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityTracer.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityTracer.kt
@@ -6,6 +6,7 @@
 package io.opentelemetry.android.instrumentation.activity
 
 import android.app.Activity
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.common.RumConstants.ACTIVITY_LIFECYCLE_EVENT_KEY
 import io.opentelemetry.android.common.RumConstants.ACTIVITY_LIFECYCLE_SPAN_NAME
 import io.opentelemetry.android.common.RumConstants.APP_START_SPAN_NAME
@@ -34,11 +35,13 @@ internal class ActivityTracer(
             return this
         }
         activeSpan.startSpan { createLifecycleSpan(lifecycleEvent) }
+        RumDiagnostics.d { "activity: span start event=$lifecycleEvent activity=$activityName" }
         return this
     }
 
     fun startActivityCreation(): ActivityTracer {
         activeSpan.startSpan { this.makeCreationSpan() }
+        RumDiagnostics.d { "activity: span start event=Created activity=$activityName" }
         return this
     }
 
@@ -120,6 +123,7 @@ internal class ActivityTracer(
         // out of the startup phase.
         appStartupTimer.end()
         activeSpan.endActiveSpan()
+        RumDiagnostics.d { "activity: span end activity=$activityName" }
     }
 
     fun addPreviousScreenAttribute(): ActivityTracer {

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer.kt
@@ -16,6 +16,7 @@ import androidx.annotation.RequiresApi
 import io.opentelemetry.android.common.StartupTimestampProvider
 import java.util.ServiceLoader
 import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.internal.services.visiblescreen.activities.DefaultingActivityLifecycleCallbacks
 import android.view.ViewTreeObserver
 import io.opentelemetry.api.common.Attributes
@@ -284,7 +285,7 @@ internal class AppStartupTimer(
         uiInitStarted = true
         startupSpan?.let { recordContentProviderEndEvents(it) }
         if (spanStartNanos + MAX_TIME_TO_UI_INIT < startupClock.now()) {
-            Log.d(RumConstants.OTEL_RUM_LOG_TAG, "Max time to UI init exceeded")
+            RumDiagnostics.d { "activityStartup: max time to UI init exceeded" }
             uiInitTooLate = true
             clear()
         }

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer.kt
@@ -11,7 +11,6 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Process
 import android.os.SystemClock
-import android.util.Log
 import androidx.annotation.RequiresApi
 import io.opentelemetry.android.common.StartupTimestampProvider
 import java.util.ServiceLoader

--- a/instrumentation/android-log/library/build.gradle.kts
+++ b/instrumentation/android-log/library/build.gradle.kts
@@ -11,6 +11,7 @@ android {
 
 dependencies {
     api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
+    implementation(project(":common"))
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":agent-api"))
 

--- a/instrumentation/android-log/library/src/main/java/io/opentelemetry/instrumentation/library/log/AndroidLogInstrumentation.kt
+++ b/instrumentation/android-log/library/src/main/java/io/opentelemetry/instrumentation/library/log/AndroidLogInstrumentation.kt
@@ -8,12 +8,14 @@ package io.opentelemetry.instrumentation.library.log
 import android.content.Context
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.instrumentation.library.log.internal.LogRecordBuilderCreator.configure
 
 @AutoService(AndroidInstrumentation::class)
 class AndroidLogInstrumentation : AndroidInstrumentation {
     override fun install(context: Context, openTelemetryRum: OpenTelemetryRum) {
+        RumDiagnostics.d { "androidLog: substitution install" }
         configure(openTelemetryRum.openTelemetry)
     }
 

--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrInstrumentation.kt
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrInstrumentation.kt
@@ -10,6 +10,7 @@ import android.os.Looper
 import androidx.annotation.VisibleForTesting
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
 import io.opentelemetry.android.internal.services.Services.Companion.get
@@ -52,6 +53,7 @@ class AnrInstrumentation : AndroidInstrumentation {
                 get(context).appLifecycle,
                 openTelemetryRum.openTelemetry,
             )
+        RumDiagnostics.d { "anr: watchdog install" }
         anrDetector.start()
     }
 

--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrWatcher.kt
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrWatcher.kt
@@ -6,6 +6,7 @@
 package io.opentelemetry.android.instrumentation.anr
 
 import android.os.Handler
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.common.internal.utils.threadIdCompat
 import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
 import io.opentelemetry.api.common.Attributes
@@ -67,6 +68,7 @@ internal class AnrWatcher(
         }
         if (anrCounter.incrementAndGet() >= 5) {
             val stackTrace = mainThread.stackTrace
+            RumDiagnostics.d { "anr: detected thread=${mainThread.name}" }
             emitAnrEvent(stackTrace)
             // only report once per 5s.
             anrCounter.set(0)

--- a/instrumentation/compose/click/build.gradle.kts
+++ b/instrumentation/compose/click/build.gradle.kts
@@ -16,6 +16,7 @@ android {
 dependencies {
     api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
 
+    implementation(project(":common"))
     implementation(project(":agent-api"))
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":services"))

--- a/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickInstrumentation.kt
+++ b/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickInstrumentation.kt
@@ -9,6 +9,7 @@ import android.app.Application
 import android.content.Context
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 
 @AutoService(AndroidInstrumentation::class)
@@ -16,6 +17,7 @@ class ComposeClickInstrumentation : AndroidInstrumentation {
     override val name: String = "compose.click"
 
     override fun install(context: Context, openTelemetryRum: OpenTelemetryRum) {
+        RumDiagnostics.d { "composeClick: install" }
         (context as? Application)?.registerActivityLifecycleCallbacks(
             ComposeClickActivityCallback(
                 ComposeClickEventGenerator(

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.kt
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android.instrumentation.crash
 
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.common.internal.utils.threadIdCompat
 import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
 import io.opentelemetry.api.OpenTelemetry
@@ -37,6 +38,7 @@ internal class CrashReporter(
     }
 
     private fun processCrash(crashDetails: CrashDetails) {
+        RumDiagnostics.d { "crash: captured type=${crashDetails.cause.javaClass.simpleName}" }
         val throwable = crashDetails.cause
         val thread = crashDetails.thread
         val attributesBuilder =

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporterInstrumentation.kt
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporterInstrumentation.kt
@@ -8,6 +8,7 @@ package io.opentelemetry.android.instrumentation.crash
 import android.content.Context
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
 
@@ -25,6 +26,7 @@ class CrashReporterInstrumentation : AndroidInstrumentation {
     override fun install(context: Context, openTelemetryRum: OpenTelemetryRum) {
         addAttributesExtractor(RuntimeDetailsExtractor.create(context))
         val crashReporter = CrashReporter(additionalExtractors)
+        RumDiagnostics.d { "crash: handler install" }
         crashReporter.install(openTelemetryRum.openTelemetry)
     }
 

--- a/instrumentation/fragment/src/main/java/io/opentelemetry/android/instrumentation/fragment/FragmentTracer.kt
+++ b/instrumentation/fragment/src/main/java/io/opentelemetry/android/instrumentation/fragment/FragmentTracer.kt
@@ -7,6 +7,7 @@ package io.opentelemetry.android.instrumentation.fragment
 
 import androidx.fragment.app.Fragment
 import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.common.ActiveSpan
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.Span
@@ -25,11 +26,13 @@ internal class FragmentTracer(
             return this
         }
         activeSpan.startSpan { createLifecycleSpan(lifecycleEvent) }
+        RumDiagnostics.d { "fragment: span start event=$lifecycleEvent fragment=$fragmentName" }
         return this
     }
 
     fun startFragmentCreation(): FragmentTracer {
         activeSpan.startSpan { createLifecycleSpan("Created") }
+        RumDiagnostics.d { "fragment: span start event=Created fragment=$fragmentName" }
         return this
     }
 
@@ -48,6 +51,7 @@ internal class FragmentTracer(
 
     fun endActiveSpan() {
         activeSpan.endActiveSpan()
+        RumDiagnostics.d { "fragment: span end fragment=$fragmentName" }
     }
 
     fun addPreviousScreenAttribute(): FragmentTracer {

--- a/instrumentation/httpurlconnection/library/build.gradle.kts
+++ b/instrumentation/httpurlconnection/library/build.gradle.kts
@@ -11,6 +11,7 @@ android {
 
 dependencies {
     api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
+    implementation(project(":common"))
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":agent-api"))
     api(libs.opentelemetry.context)

--- a/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlInstrumentation.kt
+++ b/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlInstrumentation.kt
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.library.httpurlconnection
 import android.content.Context
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
 import io.opentelemetry.instrumentation.api.internal.HttpConstants
@@ -107,6 +108,7 @@ class HttpUrlInstrumentation : AndroidInstrumentation {
     fun emitExperimentalHttpClientMetrics(): Boolean = emitExperimentalHttpClientMetrics
 
     override fun install(context: Context, openTelemetryRum: OpenTelemetryRum) {
+        RumDiagnostics.d { "httpUrlConnection: substitution install" }
         HttpUrlConnectionSingletons.configure(this, openTelemetryRum.openTelemetry)
     }
 

--- a/instrumentation/hybrid-click/build.gradle.kts
+++ b/instrumentation/hybrid-click/build.gradle.kts
@@ -16,6 +16,7 @@ android {
 dependencies {
     api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
 
+    implementation(project(":common"))
     implementation(project(":agent-api"))
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":services"))

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGenerator.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGenerator.kt
@@ -11,6 +11,7 @@ import android.view.MotionEvent
 import android.view.ViewConfiguration
 import android.view.View
 import android.view.Window
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.ATTR_WIDGET_SOURCE
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.SOURCE_COMPOSE
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.TapGestureClassifier
@@ -132,6 +133,7 @@ internal class ClickEventGenerator(
             return
         }
         window.callback = WindowCallbackWrapper(currentCallback, this)
+        RumDiagnostics.d { "hybridClick: window callback attached" }
     }
 
     /**
@@ -148,6 +150,10 @@ internal class ClickEventGenerator(
             findComposeTarget(window.decorView, event.x, event.y)
                 ?: viewTapTargetDetector.findTapTarget(window.decorView, event.x, event.y)
                 ?: return
+
+        RumDiagnostics.d {
+            "hybridClick: tap -> Click span target=${target.widgetId} source=${target.source}"
+        }
 
         val span =
             tracer.spanBuilder(UI_CLICK_SPAN_NAME)

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/HybridClickInstrumentation.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/HybridClickInstrumentation.kt
@@ -9,6 +9,7 @@ import android.app.Application
 import android.content.Context
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.ConfigurableHybridClickInstrumentation
 
@@ -35,6 +36,7 @@ class HybridClickInstrumentation : AndroidInstrumentation, ConfigurableHybridCli
         if (activityLifecycleCallback != null) {
             return
         }
+        RumDiagnostics.d { "hybridClick: install" }
 
         val tracer =
             openTelemetryRum.openTelemetry

--- a/instrumentation/navigation-common/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/common/NavigationSpanEmitter.kt
+++ b/instrumentation/navigation-common/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/common/NavigationSpanEmitter.kt
@@ -6,6 +6,7 @@
 package io.opentelemetry.android.instrumentation.navigation.common
 
 import io.opentelemetry.android.common.RumConstants.SCREEN_NAME_KEY
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.navigation.common.NavigationConstants.NAVIGATION_DESTINATION_NAME_KEY
 import io.opentelemetry.android.instrumentation.navigation.common.NavigationConstants.NAVIGATION_DESTINATION_TYPE_KEY
 import io.opentelemetry.android.instrumentation.navigation.common.NavigationConstants.NAVIGATION_ENTRY_TYPE_KEY
@@ -52,5 +53,8 @@ class NavigationSpanEmitter(
         // Set screen.name after start so it wins over default attribute appenders.
         span.setAttribute(SCREEN_NAME_KEY, candidate.destination.name)
         span.end()
+        RumDiagnostics.d {
+            "navigation: span dest=${candidate.destination.name} type=${candidate.destination.type.name.lowercase()}"
+        }
     }
 }

--- a/instrumentation/navigation-compose-nav2/build.gradle.kts
+++ b/instrumentation/navigation-compose-nav2/build.gradle.kts
@@ -30,6 +30,7 @@ android {
 dependencies {
     api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
 
+    implementation(project(":common"))
     implementation(project(":agent-api"))
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":instrumentation:common-api"))

--- a/instrumentation/navigation-compose-nav2/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/ComposeNav2Instrumentation.kt
+++ b/instrumentation/navigation-compose-nav2/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/ComposeNav2Instrumentation.kt
@@ -8,6 +8,7 @@ package io.opentelemetry.android.instrumentation.navigation.compose.nav2
 import android.content.Context
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 
 @AutoService(AndroidInstrumentation::class)
@@ -18,6 +19,7 @@ class ComposeNav2Instrumentation : AndroidInstrumentation {
         context: Context,
         openTelemetryRum: OpenTelemetryRum,
     ) {
+        RumDiagnostics.d { "navigationComposeNav2: install" }
         NavObserverRumHolder.set(openTelemetryRum)
     }
 

--- a/instrumentation/navigation-compose-nav3/build.gradle.kts
+++ b/instrumentation/navigation-compose-nav3/build.gradle.kts
@@ -31,6 +31,7 @@ android {
 dependencies {
     api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
 
+    implementation(project(":common"))
     implementation(project(":agent-api"))
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":instrumentation:common-api"))

--- a/instrumentation/navigation-compose-nav3/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav3/ComposeNav3Instrumentation.kt
+++ b/instrumentation/navigation-compose-nav3/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav3/ComposeNav3Instrumentation.kt
@@ -8,6 +8,7 @@ package io.opentelemetry.android.instrumentation.navigation.compose.nav3
 import android.content.Context
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 
 @AutoService(AndroidInstrumentation::class)
@@ -18,6 +19,7 @@ class ComposeNav3Instrumentation : AndroidInstrumentation {
         context: Context,
         openTelemetryRum: OpenTelemetryRum,
     ) {
+        RumDiagnostics.d { "navigationComposeNav3: install" }
         NavObserverRumHolder.set(openTelemetryRum)
     }
 

--- a/instrumentation/navigation-view/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationInstrumentation.kt
+++ b/instrumentation/navigation-view/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationInstrumentation.kt
@@ -9,6 +9,7 @@ import android.app.Application
 import android.content.Context
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.common.Constants.INSTRUMENTATION_SCOPE
 import io.opentelemetry.android.instrumentation.navigation.common.NavigationSpanEmitter
@@ -26,6 +27,7 @@ class ViewNavigationInstrumentation : AndroidInstrumentation {
         if (activityLifecycleCallbacks != null) {
             return
         }
+        RumDiagnostics.d { "navigationView: install" }
         val tracer = openTelemetryRum.openTelemetry.getTracer(INSTRUMENTATION_SCOPE)
         val callback = ViewNavigationCollector(NavigationSpanEmitter(tracer), openTelemetryRum.clock)
         activityLifecycleCallbacks = callback

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkApplicationListener.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkApplicationListener.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android.instrumentation.network
 
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateListener
 import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
@@ -71,6 +72,7 @@ internal class NetworkApplicationListener(
                 .setEventName("network.change")
                 .setAllAttributes(attributesBuilder.build())
                 .emit()
+            RumDiagnostics.d { "network: change status=${currentNetwork.state}" }
         }
     }
 }

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation.kt
@@ -8,6 +8,7 @@ package io.opentelemetry.android.instrumentation.network
 import android.content.Context
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.internal.services.Services.Companion.get
@@ -37,6 +38,7 @@ class NetworkChangeInstrumentation : AndroidInstrumentation {
         val services = get(context)
         val listener = NetworkApplicationListener(services.currentNetworkProvider)
         val logger = openTelemetryRum.openTelemetry.logsBridge["io.opentelemetry.network"]
+        RumDiagnostics.d { "network: monitoring install" }
         listener.startMonitoring(logger, additionalAttributeExtractors)
         services.appLifecycle.registerListener(listener)
         networkApplicationListener = listener

--- a/instrumentation/okhttp3-websocket/library/build.gradle.kts
+++ b/instrumentation/okhttp3-websocket/library/build.gradle.kts
@@ -15,6 +15,7 @@ android {
 
 dependencies {
     api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
+    implementation(project(":common"))
     implementation(project(":agent-api"))
     implementation(project(":instrumentation:android-instrumentation"))
     compileOnly(libs.okhttp)

--- a/instrumentation/okhttp3-websocket/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/websocket/internal/OkHttpWebsocketInstrumentation.kt
+++ b/instrumentation/okhttp3-websocket/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/websocket/internal/OkHttpWebsocketInstrumentation.kt
@@ -8,11 +8,13 @@ package io.opentelemetry.instrumentation.library.okhttp.websocket.internal
 import android.content.Context
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 
 @AutoService(AndroidInstrumentation::class)
 class OkHttpWebsocketInstrumentation : AndroidInstrumentation {
     override fun install(context: Context, openTelemetryRum: OpenTelemetryRum) {
+        RumDiagnostics.d { "okhttpWs: install" }
         WebsocketListenerWrapper.configure(openTelemetryRum.openTelemetry)
     }
 

--- a/instrumentation/okhttp3-websocket/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/websocket/internal/WebsocketListenerWrapper.kt
+++ b/instrumentation/okhttp3-websocket/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/websocket/internal/WebsocketListenerWrapper.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.library.okhttp.websocket.internal
 
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
@@ -96,6 +97,7 @@ class WebsocketListenerWrapper(
         eventName: String,
         attributes: Attributes,
     ) {
+        RumDiagnostics.d { "okhttpWs: event=$eventName" }
         logger
             .logRecordBuilder()
             .setEventName(eventName)

--- a/instrumentation/okhttp3/library/build.gradle.kts
+++ b/instrumentation/okhttp3/library/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 }
 
 dependencies {
+    implementation(project(":common"))
     implementation(project(":instrumentation:android-instrumentation"))
     compileOnly(libs.okhttp)
     api(libs.opentelemetry.instrumentation.okhttp)

--- a/instrumentation/okhttp3/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/OkHttpInstrumentation.kt
+++ b/instrumentation/okhttp3/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/OkHttpInstrumentation.kt
@@ -8,6 +8,7 @@ package io.opentelemetry.instrumentation.library.okhttp
 import android.content.Context
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
 import io.opentelemetry.instrumentation.api.internal.HttpConstants
@@ -105,6 +106,7 @@ class OkHttpInstrumentation : AndroidInstrumentation {
     fun emitExperimentalHttpClientTelemetry(): Boolean = emitExperimentalHttpClientTelemetry
 
     override fun install(context: Context, openTelemetryRum: OpenTelemetryRum) {
+        RumDiagnostics.d { "okhttp: interceptor install" }
         OkHttpSingletons.configure(this, openTelemetryRum.openTelemetry)
     }
 

--- a/instrumentation/okhttp3/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/internal/OkHttpSingletons.kt
+++ b/instrumentation/okhttp3/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/internal/OkHttpSingletons.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.library.okhttp.internal
 
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.context.Context
 import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpClientServicePeerAttributesExtractor
@@ -72,7 +73,17 @@ object OkHttpSingletons {
         val instrumenter = instrumenterBuilder.build()
 
         connectionErrorInterceptor = ConnectionErrorSpanInterceptor(instrumenter)
-        tracingInterceptor = TracingInterceptor(instrumenter, openTelemetry.propagators)
+        val tracing = TracingInterceptor(instrumenter, openTelemetry.propagators)
+        tracingInterceptor =
+            Interceptor { chain ->
+                val request = chain.request()
+                RumDiagnostics.d { "okhttp: request method=${request.method} host=${request.url.host}" }
+                val response = tracing.intercept(chain)
+                RumDiagnostics.d {
+                    "okhttp: response code=${response.code} method=${request.method} host=${request.url.host}"
+                }
+                response
+            }
     }
 
     @JvmField

--- a/instrumentation/screen-orientation/build.gradle.kts
+++ b/instrumentation/screen-orientation/build.gradle.kts
@@ -18,6 +18,7 @@ android {
 }
 
 dependencies {
+    implementation(project(":common"))
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":agent-api"))
 }

--- a/instrumentation/screen-orientation/src/main/java/io/opentelemetry/android/instrumentation/screenorientation/ScreenOrientationDetector.kt
+++ b/instrumentation/screen-orientation/src/main/java/io/opentelemetry/android/instrumentation/screenorientation/ScreenOrientationDetector.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Configuration.ORIENTATION_LANDSCAPE
 import android.content.res.Configuration.ORIENTATION_PORTRAIT
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.api.logs.Logger
 
 /**
@@ -39,6 +40,7 @@ internal class ScreenOrientationDetector(
             .setEventName(EVENT_NAME)
             .setAttribute(SCREEN_ORIENTATION, orientation)
             .emit()
+        RumDiagnostics.d { "screenOrientation: change orientation=$orientation" }
     }
 
     private val Int.name: String

--- a/instrumentation/sessions/src/main/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionIdEventSender.kt
+++ b/instrumentation/sessions/src/main/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionIdEventSender.kt
@@ -6,6 +6,7 @@
 package io.opentelemetry.android.instrumentation.sessions
 
 import io.opentelemetry.android.common.RumConstants.Events.EVENT_SESSION_END
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.common.RumConstants.Events.EVENT_SESSION_START
 import io.opentelemetry.android.session.Session
 import io.opentelemetry.android.session.SessionObserver
@@ -34,6 +35,7 @@ internal class SessionIdEventSender(
             eventBuilder.setAttribute(SESSION_PREVIOUS_ID, previousSessionId)
         }
         eventBuilder.emit()
+        RumDiagnostics.d { "session: start id=${newSession.id}" }
     }
 
     override fun onSessionEnded(session: Session) {
@@ -45,5 +47,6 @@ internal class SessionIdEventSender(
             .setEventName(EVENT_SESSION_END)
             .setAttribute(SESSION_ID, session.id)
             .emit()
+        RumDiagnostics.d { "session: end id=${session.id}" }
     }
 }

--- a/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporter.kt
+++ b/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporter.kt
@@ -5,8 +5,7 @@
 
 package io.opentelemetry.android.instrumentation.slowrendering
 
-import android.util.Log
-import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Logger
@@ -31,11 +30,8 @@ internal class EventJankReporter(
             val durationMillis = entry.key
             if ((durationMillis / 1000.0) > threshold) {
                 val count = entry.value
-                if (debugVerbose) {
-                    Log.d(
-                        RumConstants.OTEL_RUM_LOG_TAG,
-                        "* Slow render detected: $durationMillis ms. $count times",
-                    )
+                if (debugVerbose || RumDiagnostics.verbose) {
+                    RumDiagnostics.d { "slowRendering: slow frame ${durationMillis}ms count=$count" }
                 }
                 frameCount += count
             }

--- a/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentation.kt
+++ b/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentation.kt
@@ -12,6 +12,7 @@ import android.util.Log
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import java.time.Duration
 
@@ -82,9 +83,11 @@ class SlowRenderingInstrumentation : AndroidInstrumentation {
             return
         }
 
+        val verbose = debugVerbose || RumDiagnostics.verbose
+        RumDiagnostics.d { "slowRendering: install verbose=$verbose" }
         val logger = openTelemetryRum.openTelemetry.logsBridge.get("app.jank")
-        var jankReporter: JankReporter = EventJankReporter(logger, SLOW_THRESHOLD_MS / 1000.0, debugVerbose)
-        jankReporter = jankReporter.combine(EventJankReporter(logger, FROZEN_THRESHOLD_MS / 1000.0, debugVerbose))
+        var jankReporter: JankReporter = EventJankReporter(logger, SLOW_THRESHOLD_MS / 1000.0, verbose)
+        jankReporter = jankReporter.combine(EventJankReporter(logger, FROZEN_THRESHOLD_MS / 1000.0, verbose))
 
         if (useDeprecatedSpan) {
             val tracer = openTelemetryRum.openTelemetry.getTracer("io.opentelemetry.slow-rendering")

--- a/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SpanBasedJankReporter.kt
+++ b/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SpanBasedJankReporter.kt
@@ -5,8 +5,7 @@
 
 package io.opentelemetry.android.instrumentation.slowrendering
 
-import android.util.Log
-import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
 import java.time.Instant
@@ -28,16 +27,10 @@ internal class SpanBasedJankReporter(
             val duration = entry.key
             val count = entry.value
             if (duration > FROZEN_THRESHOLD_MS) {
-                Log.d(
-                    RumConstants.OTEL_RUM_LOG_TAG,
-                    "* FROZEN RENDER DETECTED: $duration ms.$count times",
-                )
+                RumDiagnostics.d { "slowRendering: frozen frame ${duration}ms count=$count" }
                 frozenCount += count
             } else if (duration > SLOW_THRESHOLD_MS) {
-                Log.d(
-                    RumConstants.OTEL_RUM_LOG_TAG,
-                    "* Slow render detected: $duration ms. $count times",
-                )
+                RumDiagnostics.d { "slowRendering: slow frame ${duration}ms count=$count" }
                 slowCount += count
             }
         }

--- a/instrumentation/startup/library/src/main/java/io/opentelemetry/android/instrumentation/startup/EarlyStartupContentProvider.kt
+++ b/instrumentation/startup/library/src/main/java/io/opentelemetry/android/instrumentation/startup/EarlyStartupContentProvider.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android.instrumentation.startup
 
+import io.opentelemetry.android.common.RumDiagnostics
 import android.content.ContentProvider
 import android.content.ContentValues
 import android.database.Cursor
@@ -31,6 +32,7 @@ import android.net.Uri
 class EarlyStartupContentProvider : ContentProvider() {
     override fun onCreate(): Boolean {
         ProcessStartTimestamps.contentProviderEpochMs = System.currentTimeMillis()
+        RumDiagnostics.d { "startup: content provider init timestamp captured" }
         return true
     }
 

--- a/instrumentation/startup/library/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.kt
+++ b/instrumentation/startup/library/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.kt
@@ -7,6 +7,7 @@ package io.opentelemetry.android.instrumentation.startup
 
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.internal.initialization.InitializationEvents
 import io.opentelemetry.api.OpenTelemetry
@@ -64,6 +65,7 @@ class SdkInitializationEvents(
     internal fun finish(openTelemetry: OpenTelemetry) {
         val logger = openTelemetry.logsBridge.loggerBuilder("otel.initialization.events").build()
         eventLogger.set(logger)
+        RumDiagnostics.d { "startup: finish emitting ${events.size} queued init events" }
         logger.emitInitEvents()
     }
 

--- a/instrumentation/startup/library/src/main/java/io/opentelemetry/android/instrumentation/startup/StartupInstrumentation.kt
+++ b/instrumentation/startup/library/src/main/java/io/opentelemetry/android/instrumentation/startup/StartupInstrumentation.kt
@@ -8,6 +8,7 @@ package io.opentelemetry.android.instrumentation.startup
 import android.content.Context
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.internal.initialization.InitializationEvents
 
@@ -16,6 +17,7 @@ class StartupInstrumentation : AndroidInstrumentation {
     override val name: String = "startup"
 
     override fun install(context: Context, openTelemetryRum: OpenTelemetryRum) {
+        RumDiagnostics.d { "startup: emit init events" }
         val events = InitializationEvents.get()
         if (events is SdkInitializationEvents) {
             events.finish(openTelemetryRum.openTelemetry)

--- a/instrumentation/system-metrics/src/main/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsInstrumentation.kt
+++ b/instrumentation/system-metrics/src/main/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsInstrumentation.kt
@@ -8,6 +8,8 @@ package io.opentelemetry.android.instrumentation.systemmetrics
 import android.content.Context
 import android.util.Log
 import com.google.auto.service.AutoService
+import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.ConfigurableSystemMetricsInstrumentation
@@ -34,11 +36,12 @@ class SystemMetricsInstrumentation : AndroidInstrumentation, ConfigurableSystemM
         openTelemetryRum: OpenTelemetryRum,
     ) {
         if (scheduler != null) return
+        RumDiagnostics.d { "systemMetrics: install interval=${collectionIntervalSeconds}s" }
         val newScheduler = Executors.newSingleThreadScheduledExecutor { r ->
             Thread(r, "otel-system-metrics").apply {
                 isDaemon = true
                 setUncaughtExceptionHandler { _, e ->
-                    Log.e("OpenTelemetryRum", "SystemMetrics: uncaught exception on scheduler thread", e)
+                    Log.e(RumConstants.OTEL_RUM_LOG_TAG, "SystemMetrics: uncaught exception on scheduler thread", e)
                 }
             }
         }

--- a/instrumentation/system-metrics/src/main/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsSpanEmitter.kt
+++ b/instrumentation/system-metrics/src/main/kotlin/io/opentelemetry/android/instrumentation/systemmetrics/SystemMetricsSpanEmitter.kt
@@ -10,6 +10,7 @@ import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.common.RumDiagnostics
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
@@ -106,6 +107,9 @@ internal class SystemMetricsSpanEmitter(
                 .startSpan()
         span.addEvent("app.metrics", buildAttributes(sample))
         span.end()
+        RumDiagnostics.d {
+            "systemMetrics: emit cpu=${sample.cpuUsage} threads=${sample.threadCount}"
+        }
     }
 
     private fun buildAttributes(sample: ProcessSample): Attributes =

--- a/instrumentation/view-click/build.gradle.kts
+++ b/instrumentation/view-click/build.gradle.kts
@@ -15,6 +15,7 @@ android {
 
 dependencies {
     api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
+    implementation(project(":common"))
     implementation(project(":services"))
     implementation(project(":agent-api"))
     implementation(project(":instrumentation:android-instrumentation"))

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
@@ -10,6 +10,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_CLICK_EVENT_NAME
 import io.opentelemetry.android.instrumentation.view.click.internal.HARDWARE_POINTER_BUTTON
 import io.opentelemetry.android.instrumentation.view.click.internal.HARDWARE_POINTER_CLICKS
@@ -46,6 +47,7 @@ internal class ViewClickEventGenerator(
                     .emit()
 
                 findTargetForTap(window.decorView, motionEvent.x, motionEvent.y)?.let { view ->
+                    RumDiagnostics.d { "viewClick: double-tap view=${view.id}" }
                     createEvent(VIEW_CLICK_EVENT_NAME, tapEvent, 2)
                         .setAllAttributes(createViewAttributes(view))
                         .emit()
@@ -67,6 +69,7 @@ internal class ViewClickEventGenerator(
                     .emit()
 
                 findTargetForTap(window.decorView, motionEvent.x, motionEvent.y)?.let { view ->
+                    RumDiagnostics.d { "viewClick: tap view=${view.id}" }
                     createEvent(VIEW_CLICK_EVENT_NAME, tapEvent, 1)
                         .setAllAttributes(createViewAttributes(view))
                         .emit()

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentation.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentation.kt
@@ -9,6 +9,7 @@ import android.app.Application
 import android.content.Context
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 
 @AutoService(AndroidInstrumentation::class)
@@ -16,6 +17,7 @@ class ViewClickInstrumentation : AndroidInstrumentation {
     override val name: String = "view.click"
 
     override fun install(context: Context, openTelemetryRum: OpenTelemetryRum) {
+        RumDiagnostics.d { "viewClick: install" }
         (context as? Application)?.registerActivityLifecycleCallbacks(
             ViewClickActivityCallback(
                 ViewClickEventGenerator(

--- a/services/src/main/java/io/opentelemetry/android/internal/services/applifecycle/ApplicationStateWatcher.kt
+++ b/services/src/main/java/io/opentelemetry/android/internal/services/applifecycle/ApplicationStateWatcher.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android.internal.services.applifecycle
 
+import io.opentelemetry.android.common.RumDiagnostics
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import java.io.Closeable
@@ -20,12 +21,14 @@ internal class ApplicationStateWatcher :
         CopyOnWriteArrayList()
 
     override fun onStart(owner: LifecycleOwner) {
+        RumDiagnostics.d { "lifecycle: foreground" }
         for (listener in applicationStateListeners) {
             listener.onApplicationForegrounded()
         }
     }
 
     override fun onStop(owner: LifecycleOwner) {
+        RumDiagnostics.d { "lifecycle: background" }
         for (listener in applicationStateListeners) {
             listener.onApplicationBackgrounded()
         }

--- a/services/src/main/java/io/opentelemetry/android/internal/services/network/CurrentNetworkProviderImpl.kt
+++ b/services/src/main/java/io/opentelemetry/android/internal/services/network/CurrentNetworkProviderImpl.kt
@@ -14,6 +14,7 @@ import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
 import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.internal.services.network.detector.NetworkDetector
 import java.util.concurrent.CopyOnWriteArrayList
@@ -115,7 +116,7 @@ internal class CurrentNetworkProviderImpl(
     private inner class ConnectionMonitor : NetworkCallback() {
         override fun onAvailable(network: Network) {
             val activeNetwork = refreshNetworkStatus()
-            Log.d(RumConstants.OTEL_RUM_LOG_TAG, "  onAvailable: currentNetwork=$activeNetwork")
+            RumDiagnostics.d { "network: onAvailable state=${activeNetwork.state}" }
 
             notifyListeners(activeNetwork)
         }
@@ -127,7 +128,7 @@ internal class CurrentNetworkProviderImpl(
             // state at the right time during this event.
             val currentNetwork = CurrentNetworkProvider.NO_NETWORK
             this@CurrentNetworkProviderImpl.currentNetwork = currentNetwork
-            Log.d(RumConstants.OTEL_RUM_LOG_TAG, "  onLost: currentNetwork=$currentNetwork")
+            RumDiagnostics.d { "network: onLost" }
 
             notifyListeners(currentNetwork)
         }


### PR DESCRIPTION
## Summary

- Introduces `RumDiagnostics` in `:common` — a global, opt-in verbose diagnostics helper that writes to Logcat under the `OpenTelemetryRum` tag when enabled.
- Adds `diagnosticLogging` to the agent DSL (`OpenTelemetryConfiguration`) so apps can turn diagnostics on during SDK initialization.
- Wires diagnostic log lines through instrumentations (activity, fragment, network, okhttp, startup, sessions, navigation, clicks, etc.), core disk buffering, and Android services.
- Adds OTLP export logging decorators (`LoggingSpanExporterDecorator`, `LoggingMetricExporterDecorator`, `LoggingLogRecordExporterDecorator`) that log export batch summaries when diagnostic logging is on.
- Fixes missing `implementation(project(":common"))` in four instrumentation modules that reference `RumDiagnostics`, resolving `publishToMavenLocal` compile failures.

## Usage

```kotlin
OpenTelemetryRumInitializer.initialize(application) {
    diagnosticLogging = true
    // ...
}
```

When enabled, instrumentations emit `RumDiagnostics.d { ... }` lines to Logcat and exporters log batch export summaries. Zero overhead when `diagnosticLogging` is `false` (default).

## Key changes

| Area | Change |
|------|--------|
| `:common` | New `RumDiagnostics` object + unit tests |
| `android-agent` | `diagnosticLogging` DSL knob; export decorators; initializer wiring |
| `instrumentation/*` | Diagnostic hooks on install/runtime events across ~20 modules |
| `core` / `services` | Disk-buffer and lifecycle/network diagnostic messages |
| Gradle | Add `:common` dep to `view-click`, `compose-click`, `navigation-compose-nav2`, `navigation-compose-nav3` |

## Build fix

Four modules imported `io.opentelemetry.android.common.RumDiagnostics` without declaring `implementation(project(":common"))`, causing release compile failures:

```
Unresolved reference 'common'
Unresolved reference 'RumDiagnostics'
```

Other instrumentation modules already had the explicit `:common` dependency; this PR aligns the remaining four.

## Test plan

- [x] `./gradlew :common:test :android-agent:test`
- [x] `./gradlew :instrumentation:view-click:compileReleaseKotlin :instrumentation:compose:click:compileReleaseKotlin :instrumentation:navigation-compose-nav2:compileReleaseKotlin :instrumentation:navigation-compose-nav3:compileReleaseKotlin`
- [x] `./gradlew check`
- [x] `./gradlew publishToMavenLocal`
- [x] Manual: initialize SDK with `diagnosticLogging = true` and verify Logcat output under `OpenTelemetryRum` tag during app lifecycle, network, and export events