### PR TITLE
feat(hybrid-click): multi-window tracking, toggle state, and richer l…

### DIFF
--- a/instrumentation/hybrid-click/DESIGN.md
+++ b/instrumentation/hybrid-click/DESIGN.md
@@ -191,17 +191,63 @@ This prevents double-detection — the Compose detector has already handled anyt
 
 Every qualified tap produces one `ui.click` span with these attributes:
 
-| Attribute                     | Source                                  | Example              |
-|-------------------------------|-----------------------------------------|----------------------|
-| `app.widget.id`               | Node hashCode (Compose) or View ID      | `"2131231045"`       |
-| `app.widget.name`             | Semantic label or resource entry name    | `"btn_pay"`          |
-| `app.screen.coordinate.x`     | Tap X position in window                | `250`                |
-| `app.screen.coordinate.y`     | Tap Y position in window                | `480`                |
-| `view.label`                  | Best-effort display label               | `"Pay now"`          |
-| `view.source`                 | UI framework: `"compose"` or `"view"`   | `"compose"`          |
+| Attribute                     | Source                                       | Example              |
+|-------------------------------|----------------------------------------------|----------------------|
+| `app.widget.id`               | Node hashCode (Compose) or View ID           | `"2131231045"`       |
+| `app.widget.name`             | Best-effort display label                    | `"Pay now"`          |
+| `app.screen.coordinate.x`     | Tap X position in window                     | `250`                |
+| `app.screen.coordinate.y`     | Tap Y position in window                     | `480`                |
+| `app.widget.source`           | UI framework: `"compose"` or `"view"`        | `"compose"`          |
+| `app.widget.checked`          | Toggle state — **toggle widgets only**       | `true`               |
 
 The span is kept active for 500ms (configurable via `setActiveContextWindowMillis`) to allow
 downstream async work to correlate with the click.
+
+### `app.widget.checked`
+
+Emitted only when the tapped target is a genuine toggle — an `android.widget.CompoundButton`
+(`Switch`, `MaterialSwitch`, `CheckBox`, `RadioButton`, `ToggleButton`) or a `CheckedTextView`. It
+is **not** keyed off the `Checkable` interface, because `MaterialButton` implements `Checkable`
+while being an ordinary button (that would tag every Material button, e.g. a dialog's "OK", with
+`checked=false`).
+
+The state is read on a deferred main-loop tick rather than inline: a `CompoundButton` flips in
+`PerformClick`, which `View.onTouchEvent` *posts* on `ACTION_UP`, so the resulting (post-tap) state
+is only observable after that runnable runs. The span end is scheduled after the read so the
+attribute is always recorded before the span closes.
+
+**View only.** Compose toggles currently do not emit `app.widget.checked` — Compose state updates on
+recomposition (asynchronously), so a reliable post-tap read isn't available through this path.
+
+---
+
+## Window Tracking
+
+A tap is only seen if the window it lands in has its `Window.Callback` wrapped. `hybrid-click`
+tracks multiple windows simultaneously (the Activity window plus any dialogs stacked on it); each
+tracked window keeps its own `TapGestureClassifier`, keyed by `Window` in a `WeakHashMap`.
+
+Windows are discovered two ways:
+
+1. **Activity windows** — `ClickActivityCallback` wraps `activity.window` on resume / unwraps on
+   pause.
+2. **DialogFragment windows** — `DialogFragmentClickCallback` (a `FragmentManager
+   .FragmentLifecycleCallbacks` registered per Activity) wraps `dialog.window` on fragment resume.
+   `androidx.fragment` is a `compileOnly` dependency; registration is guarded and lazily initialized
+   so apps without fragments neither crash nor pay for it.
+
+Both mechanisms use only public SDK APIs, which keeps the module safe for security-sensitive
+deployments (no reflection into framework internals).
+
+### Not covered
+
+- **Raw dialogs** shown directly via `AlertDialog.Builder(...).show()` (i.e. not hosted in a
+  `DialogFragment`). They own a separate `Window`, but Android exposes no public, lifecycle-based
+  hook to discover them — the only known mechanisms reach into hidden framework internals
+  (`WindowManagerGlobal`/`DecorView`), which is intentionally avoided here. Apps that need these
+  captured should host them in a `DialogFragment`.
+- **`PopupWindow`-based surfaces** (overflow/`PopupMenu`, `Spinner` dropdowns). Their root views are
+  not decor views and have no `Window`/`Window.Callback` to wrap.
 
 ---
 

--- a/instrumentation/hybrid-click/build.gradle.kts
+++ b/instrumentation/hybrid-click/build.gradle.kts
@@ -26,11 +26,18 @@ dependencies {
         exclude(group = "androidx.savedstate")
     }
 
+    // Used to wrap DialogFragment windows so taps inside dialogs are tracked. compileOnly because
+    // any app using DialogFragment already provides androidx.fragment at runtime; pure-View apps
+    // without it simply skip dialog tracking (guarded at runtime).
+    compileOnly(libs.androidx.fragment)
+
     implementation(libs.opentelemetry.instrumentation.apiSemconv)
     implementation(libs.opentelemetry.semconv.incubating)
 
     testImplementation(project(":test-common"))
     testImplementation(libs.compose)
+    testImplementation(libs.androidx.fragment)
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.test.core)
+    testImplementation(libs.androidx.junit)
 }

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickActivityCallback.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickActivityCallback.kt
@@ -6,18 +6,50 @@
 package io.opentelemetry.android.instrumentation.hybrid.click
 
 import android.app.Activity
+import androidx.fragment.app.FragmentActivity
 import io.opentelemetry.android.internal.services.visiblescreen.activities.DefaultingActivityLifecycleCallbacks
+import java.util.Collections
+import java.util.WeakHashMap
 
 internal class ClickActivityCallback(
     private val clickEventGenerator: ClickEventGenerator,
 ) : DefaultingActivityLifecycleCallbacks {
+    // Lazy so the androidx.fragment classes it references are only loaded once we have confirmed
+    // (inside the guarded registerDialogTracking) that the app actually uses fragments. Creating it
+    // eagerly here would resolve FragmentManager at construction time and crash with
+    // NoClassDefFoundError on apps that exclude the compileOnly androidx.fragment dependency.
+    private val dialogCallback by lazy { DialogFragmentClickCallback(clickEventGenerator) }
+
+    /** Activities whose FragmentManager already has the dialog callback registered. */
+    private val dialogTrackedActivities: MutableSet<Activity> =
+        Collections.newSetFromMap(WeakHashMap())
+
     override fun onActivityResumed(activity: Activity) {
         super.onActivityResumed(activity)
         clickEventGenerator.startTracking(activity.window)
+        registerDialogTracking(activity)
     }
 
     override fun onActivityPaused(activity: Activity) {
         super.onActivityPaused(activity)
-        clickEventGenerator.stopTracking()
+        clickEventGenerator.stopTracking(activity.window)
+    }
+
+    /**
+     * Hooks the Activity's [androidx.fragment.app.FragmentManager] so dialog windows get tracked.
+     *
+     * Registered once per Activity (recursively, to also cover child FragmentManagers). Guarded so
+     * apps without androidx.fragment on the classpath simply skip dialog tracking instead of
+     * crashing.
+     */
+    private fun registerDialogTracking(activity: Activity) {
+        try {
+            if (activity !is FragmentActivity) return
+            if (!dialogTrackedActivities.add(activity)) return
+            activity.supportFragmentManager
+                .registerFragmentLifecycleCallbacks(dialogCallback, true)
+        } catch (_: Throwable) {
+            // androidx.fragment may be absent; dialog tracking is best-effort.
+        }
     }
 }

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGenerator.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGenerator.kt
@@ -8,10 +8,11 @@ package io.opentelemetry.android.instrumentation.hybrid.click
 import android.os.Handler
 import android.os.Looper
 import android.view.MotionEvent
-import android.view.ViewConfiguration
 import android.view.View
+import android.view.ViewConfiguration
 import android.view.Window
 import io.opentelemetry.android.common.RumDiagnostics
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.ATTR_WIDGET_CHECKED
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.ATTR_WIDGET_SOURCE
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.SOURCE_COMPOSE
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.TapGestureClassifier
@@ -21,7 +22,7 @@ import io.opentelemetry.android.instrumentation.hybrid.click.view.ViewTapTargetD
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.semconv.incubating.AppIncubatingAttributes
 import java.lang.reflect.Method
-import java.lang.ref.WeakReference
+import java.util.WeakHashMap
 
 /**
  * Generates `ui.click` spans for qualified tap gestures in hybrid View/Compose screens.
@@ -40,9 +41,14 @@ internal class ClickEventGenerator(
     private val viewTapTargetDetector: ViewTapTargetDetector = ViewTapTargetDetector(),
     private val activeContextWindowMillis: Long = DEFAULT_ACTIVE_CONTEXT_WINDOW_MILLIS,
 ) {
-    private var windowRef: WeakReference<Window>? = null
     private val mainHandler = Handler(Looper.getMainLooper())
-    private val tapGestureClassifier = TapGestureClassifier()
+
+    /**
+     * Per-window gesture state. Hybrid-click tracks several windows at once (the Activity window
+     * plus any dialog windows on top of it), so each gets its own classifier keyed by [Window];
+     * weak keys let a window's entry drop if tracking is ever left unbalanced.
+     */
+    private val tapGestureClassifiers = WeakHashMap<Window, TapGestureClassifier>()
 
     private val composeTapTargetDetector: ComposeDetectorBridge? by lazy {
         loadComposeDetector()
@@ -122,26 +128,36 @@ internal class ClickEventGenerator(
         } ?: throw NoSuchMethodException("$methodBaseName([${parameterType.name}])")
 
     /**
-     * Installs the wrapped window callback and initializes gesture thresholds.
+     * Installs the wrapped window callback and initializes gesture thresholds for [window].
+     *
+     * Safe to call repeatedly and for multiple windows at once (e.g. an Activity window plus any
+     * dialog windows stacked on top); each tracked window keeps its own gesture state.
      */
     fun startTracking(window: Window) {
-        windowRef = WeakReference(window)
-        tapGestureClassifier.touchSlopPx =
-            ViewConfiguration.get(window.decorView.context).scaledTouchSlop.toFloat()
-        val currentCallback = window.callback
+        val currentCallback = window.callback ?: return
         if (currentCallback is WindowCallbackWrapper) {
             return
         }
-        window.callback = WindowCallbackWrapper(currentCallback, this)
+        tapGestureClassifiers[window] =
+            TapGestureClassifier().apply {
+                touchSlopPx =
+                    ViewConfiguration.get(window.decorView.context).scaledTouchSlop.toFloat()
+            }
+        window.callback = WindowCallbackWrapper(currentCallback, window, this)
         RumDiagnostics.d { "hybridClick: window callback attached" }
     }
 
     /**
-     * Consumes motion events, qualifies tap gestures, resolves a tap target, and emits `ui.click`.
+     * Consumes motion events for [window], qualifies tap gestures, resolves a tap target, and emits
+     * `ui.click`. The target is always resolved against the decorView of the window that received
+     * the touch, keeping multi-window tracking correct.
      */
-    fun generateClick(motionEvent: MotionEvent?) {
-        val window = windowRef?.get() ?: return
+    fun generateClick(
+        window: Window,
+        motionEvent: MotionEvent?,
+    ) {
         val event = motionEvent ?: return
+        val tapGestureClassifier = tapGestureClassifiers[window] ?: return
         if (!tapGestureClassifier.shouldEmitClick(event)) {
             return
         }
@@ -165,13 +181,30 @@ internal class ClickEventGenerator(
                 .startSpan()
 
         val scope = span.makeCurrent()
-        mainHandler.postDelayed(
-            {
+        val endSpan =
+            Runnable {
                 scope.close()
                 span.end()
-            },
-            activeContextWindowMillis,
-        )
+            }
+
+        val checkedStateProvider = target.checkedStateProvider
+        if (checkedStateProvider == null) {
+            mainHandler.postDelayed(endSpan, activeContextWindowMillis)
+        } else {
+            // A CompoundButton flips in PerformClick, which View.onTouchEvent *posts* on ACTION_UP
+            // rather than running inline. Re-posting from inside a posted runnable (a double post)
+            // guarantees the read runs after that flip; reading inline would observe the pre-tap
+            // state. The span end is scheduled only after the read, so the attribute is always
+            // recorded before the span closes regardless of activeContextWindowMillis.
+            mainHandler.post {
+                mainHandler.post {
+                    checkedStateProvider()?.let { checked ->
+                        span.setAttribute(ATTR_WIDGET_CHECKED, checked)
+                    }
+                    mainHandler.postDelayed(endSpan, activeContextWindowMillis)
+                }
+            }
+        }
     }
 
     /**
@@ -184,16 +217,15 @@ internal class ClickEventGenerator(
     ): TapTarget? = composeTapTargetDetector?.findTapTarget(rootView, x, y)
 
     /**
-     * Restores original window callback and clears tracking state.
+     * Restores [window]'s original callback and clears its gesture state, detaching tap tracking
+     * for that specific window.
      */
-    fun stopTracking() {
-        windowRef?.get()?.run {
-            if (callback is WindowCallbackWrapper) {
-                callback = (callback as WindowCallbackWrapper).unwrap()
-            }
+    fun stopTracking(window: Window) {
+        val callback = window.callback
+        if (callback is WindowCallbackWrapper) {
+            window.callback = callback.unwrap()
         }
-        tapGestureClassifier.reset()
-        windowRef = null
+        tapGestureClassifiers.remove(window)?.reset()
     }
 
     private companion object {

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/DialogFragmentClickCallback.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/DialogFragmentClickCallback.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.hybrid.click
+
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+
+/**
+ * Tracks touch events inside [DialogFragment] windows.
+ *
+ * Dialogs render into their own [android.view.Window], distinct from the host Activity's window.
+ * Because the Activity-level callback only wraps `activity.window`, taps inside a dialog (e.g. a
+ * toggle in a card-management sheet) would otherwise never reach the instrumentation. Registering
+ * this on the host Activity's [FragmentManager] lets us wrap each dialog window as it resumes and
+ * unwrap it as it pauses.
+ */
+internal class DialogFragmentClickCallback(
+    private val clickEventGenerator: ClickEventGenerator,
+) : FragmentManager.FragmentLifecycleCallbacks() {
+    override fun onFragmentResumed(
+        fm: FragmentManager,
+        f: Fragment,
+    ) {
+        (f as? DialogFragment)?.dialog?.window?.let { clickEventGenerator.startTracking(it) }
+    }
+
+    override fun onFragmentPaused(
+        fm: FragmentManager,
+        f: Fragment,
+    ) {
+        (f as? DialogFragment)?.dialog?.window?.let { clickEventGenerator.stopTracking(it) }
+    }
+}

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/WindowCallbackWrapper.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/WindowCallbackWrapper.kt
@@ -11,15 +11,17 @@ import android.view.KeyboardShortcutGroup
 import android.view.Menu
 import android.view.MotionEvent
 import android.view.SearchEvent
+import android.view.Window
 import android.view.Window.Callback
 import androidx.annotation.RequiresApi
 
 internal class WindowCallbackWrapper(
     private val callback: Callback,
+    private val window: Window,
     private val clickEventGenerator: ClickEventGenerator,
 ) : Callback by callback {
     override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
-        clickEventGenerator.generateClick(event)
+        clickEventGenerator.generateClick(window, event)
         return callback.dispatchTouchEvent(event)
     }
 

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/shared/SemConvConstants.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/shared/SemConvConstants.kt
@@ -7,5 +7,8 @@ package io.opentelemetry.android.instrumentation.hybrid.click.shared
 
 internal const val UI_CLICK_SPAN_NAME = "ui.click"
 internal const val ATTR_WIDGET_SOURCE = "app.widget.source"
+
+/** Boolean state of a tapped toggle (switch / checkbox / radio), when the target is checkable. */
+internal const val ATTR_WIDGET_CHECKED = "app.widget.checked"
 internal const val SOURCE_COMPOSE = "compose"
 internal const val SOURCE_VIEW = "view"

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/shared/TapTarget.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/shared/TapTarget.kt
@@ -9,6 +9,11 @@ package io.opentelemetry.android.instrumentation.hybrid.click.shared
  * Normalized tap target metadata used to build hybrid click spans.
  *
  * [source] identifies where the target came from (`view` or `compose`).
+ *
+ * [checkedStateProvider] is supplied only when the target is a toggle (switch / checkbox / radio).
+ * It is a deferred read of the live checked state rather than a captured value: the click span is
+ * emitted before the touch is delegated to the underlying widget, so reading the state lazily (on
+ * the next main-loop tick) reports the *resulting* state after the toggle flips.
  */
 internal data class TapTarget(
     val source: String,
@@ -17,4 +22,5 @@ internal data class TapTarget(
     val label: String,
     val x: Long,
     val y: Long,
+    val checkedStateProvider: (() -> Boolean?)? = null,
 )

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/view/ViewTapTargetDetector.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/view/ViewTapTargetDetector.kt
@@ -7,6 +7,8 @@ package io.opentelemetry.android.instrumentation.hybrid.click.view
 
 import android.view.View
 import android.view.ViewGroup
+import android.widget.CheckedTextView
+import android.widget.CompoundButton
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.LabelResolver
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.SOURCE_VIEW
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.TapTarget
@@ -48,8 +50,24 @@ internal class ViewTapTargetDetector : TapTargetDetector {
             label = viewToLabel(clickTarget),
             x = clickTarget.x.toLong(),
             y = clickTarget.y.toLong(),
+            checkedStateProvider = checkedStateProviderOf(clickTarget),
         )
     }
+
+    /**
+     * Returns a live checked-state reader, but only for genuine toggle widgets. We intentionally do
+     * not key off the [android.widget.Checkable] interface: `MaterialButton` implements it while
+     * being an ordinary (non-toggle) button, which would otherwise tag every Material button — e.g.
+     * a dialog's "OK" — with `checked=false`.
+     */
+    private fun checkedStateProviderOf(view: View): (() -> Boolean?)? =
+        when (view) {
+            is CompoundButton -> ({ view.isChecked })
+            is CheckedTextView -> ({ view.isChecked })
+            else -> null
+        }
+
+    private fun isToggle(view: View): Boolean = view is CompoundButton || view is CheckedTextView
 
     private fun isValidClickTarget(view: View): Boolean = view.isClickable && view.isVisible
 
@@ -93,12 +111,87 @@ internal class ViewTapTargetDetector : TapTargetDetector {
     private fun viewToLabel(view: View): String {
         val contentDescription = view.contentDescription?.toString()
         val text = (view as? android.widget.TextView)?.text?.toString()
+
+        val resolvedLabel =
+            if (contentDescription.isNullOrBlank() && text.isNullOrBlank()) {
+                // When the clicked target carries no label of its own, look outward for one:
+                // 1) descendants — e.g. a clickable LinearLayout wrapping an icon + a text label
+                //    (custom bottom-nav / tab items) → "Home".
+                // 2) siblings, only for toggles — a Switch/CheckBox lives next to its title in a
+                //    row (icon | title + desc | switch), so its label is a sibling, not a child
+                //    → "Lock Card Temporarily" instead of "MaterialSwitch".
+                findLabelInChildren(view)
+                    ?: if (isToggle(view)) findLabelInSiblings(view) else null
+            } else {
+                null
+            }
+
         return LabelResolver.resolve(
-            contentDescription = contentDescription,
+            contentDescription = contentDescription ?: resolvedLabel,
             text = text,
             className = view.javaClass.simpleName,
             fallback = view.id.toString(),
         )
+    }
+
+    /**
+     * Breadth-first search over [root]'s descendants for a human-readable label, preferring a
+     * non-blank content description, then non-blank [android.widget.TextView] text.
+     */
+    private fun findLabelInChildren(root: View): String? {
+        if (root !is ViewGroup) return null
+        return firstLabelIn(childrenOf(root))
+    }
+
+    /**
+     * Searches the siblings of [view] (its parent's other descendants) for a label. Used for
+     * toggles, whose descriptive text sits beside the control rather than inside it.
+     */
+    private fun findLabelInSiblings(view: View): String? {
+        val parent = view.parent as? ViewGroup ?: return null
+        val queue = LinkedList<View>()
+        for (i in 0 until parent.childCount) {
+            val child = parent.getChildAt(i)
+            if (child !== view) {
+                queue.add(child)
+            }
+        }
+        return firstLabelIn(queue)
+    }
+
+    private fun childrenOf(group: ViewGroup): LinkedList<View> {
+        val queue = LinkedList<View>()
+        for (i in 0 until group.childCount) {
+            queue.add(group.getChildAt(i))
+        }
+        return queue
+    }
+
+    /**
+     * Drains [queue] in BFS order, returning the first non-blank content description or
+     * [android.widget.TextView] text found, enqueuing each [ViewGroup]'s children as it goes.
+     */
+    private fun firstLabelIn(queue: LinkedList<View>): String? {
+        var visited = 0
+        while (queue.isNotEmpty() && visited < MAX_LABEL_SEARCH_NODES) {
+            visited++
+            val child = queue.removeFirst()
+
+            val description = child.contentDescription?.toString()
+            if (!description.isNullOrBlank()) {
+                return description
+            }
+
+            val text = (child as? android.widget.TextView)?.text?.toString()
+            if (!text.isNullOrBlank()) {
+                return text
+            }
+
+            if (child is ViewGroup) {
+                queue.addAll(childrenOf(child))
+            }
+        }
+        return null
     }
 
     private fun isJetpackComposeView(view: View): Boolean =
@@ -106,4 +199,9 @@ internal class ViewTapTargetDetector : TapTargetDetector {
 
     private val View.isVisible: Boolean
         get() = visibility == View.VISIBLE
+
+    private companion object {
+        /** Upper bound on nodes scanned when resolving a label, to keep traversal cheap. */
+        const val MAX_LABEL_SEARCH_NODES = 100
+    }
 }

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGeneratorMultiWindowTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGeneratorMultiWindowTest.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.hybrid.click
+
+import android.content.Context
+import android.os.Looper
+import android.view.MotionEvent
+import android.view.View
+import android.view.Window
+import android.widget.Button
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import io.opentelemetry.semconv.incubating.AppIncubatingAttributes
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import androidx.test.ext.junit.runners.AndroidJUnit4
+
+/**
+ * Verifies that [ClickEventGenerator] tracks multiple windows simultaneously (an Activity window
+ * plus dialog windows stacked on top) with independent, per-window gesture state — the behavior
+ * that makes taps inside dialogs produce `ui.click` spans.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [29])
+class ClickEventGeneratorMultiWindowTest {
+    private lateinit var context: Context
+    private lateinit var exporter: InMemorySpanExporter
+    private lateinit var generator: ClickEventGenerator
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        exporter = InMemorySpanExporter.create()
+        val sdk =
+            OpenTelemetrySdk
+                .builder()
+                .setTracerProvider(
+                    SdkTracerProvider
+                        .builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                        .build(),
+                ).build()
+        generator =
+            ClickEventGenerator(
+                tracer = sdk.getTracer("test"),
+                // End the span immediately on the next main-loop idle so the exporter sees it.
+                activeContextWindowMillis = 0,
+            )
+    }
+
+    @Test
+    fun `tap on a tracked window emits a ui_click span resolved against that window`() {
+        val window = windowWith(label = "A")
+        generator.startTracking(window)
+
+        tap(window)
+
+        val spans = finishedSpans()
+        assertThat(spans).hasSize(1)
+        assertThat(spans.single().name).isEqualTo("ui.click")
+        assertThat(widgetName(spans.single())).isEqualTo("A")
+    }
+
+    @Test
+    fun `two windows are tracked independently and each resolves against its own decorView`() {
+        val windowA = windowWith(label = "A")
+        val windowB = windowWith(label = "B")
+        generator.startTracking(windowA)
+        generator.startTracking(windowB)
+
+        tap(windowA)
+        tap(windowB)
+
+        val labels = finishedSpans().map { widgetName(it) }
+        assertThat(labels).containsExactlyInAnyOrder("A", "B")
+    }
+
+    @Test
+    fun `gesture state does not leak across windows`() {
+        val windowA = windowWith(label = "A")
+        val windowB = windowWith(label = "B")
+        generator.startTracking(windowA)
+        generator.startTracking(windowB)
+
+        // A down followed by a B up must not qualify a tap on B: B never saw the down.
+        generator.generateClick(windowA, motion(MotionEvent.ACTION_DOWN))
+        generator.generateClick(windowB, motion(MotionEvent.ACTION_UP))
+
+        assertThat(finishedSpans()).isEmpty()
+    }
+
+    @Test
+    fun `stopping one window leaves the other tracking`() {
+        val windowA = windowWith(label = "A")
+        val windowB = windowWith(label = "B")
+        generator.startTracking(windowA)
+        generator.startTracking(windowB)
+
+        generator.stopTracking(windowA)
+
+        tap(windowA)
+        tap(windowB)
+
+        val labels = finishedSpans().map { widgetName(it) }
+        assertThat(labels).containsExactly("B")
+    }
+
+    @Test
+    fun `tap on an untracked window emits nothing`() {
+        val window = windowWith(label = "A")
+
+        tap(window)
+
+        assertThat(finishedSpans()).isEmpty()
+    }
+
+    /** Builds a mock [Window] whose real decorView contains a single clickable, labeled button. */
+    private fun windowWith(label: String): Window {
+        val button =
+            Button(context).apply {
+                isClickable = true
+                contentDescription = label
+            }
+        val root =
+            FrameLayout(context).apply {
+                addView(
+                    button,
+                    FrameLayout.LayoutParams(VIEW_SIZE, VIEW_SIZE),
+                )
+            }
+        val spec = View.MeasureSpec.makeMeasureSpec(VIEW_SIZE, View.MeasureSpec.EXACTLY)
+        root.measure(spec, spec)
+        root.layout(0, 0, VIEW_SIZE, VIEW_SIZE)
+
+        return mockk<Window>(relaxed = true).also { window ->
+            every { window.decorView } returns root
+        }
+    }
+
+    /** Feeds a qualified tap (down then up at the same point) for [window]. */
+    private fun tap(window: Window) {
+        generator.generateClick(window, motion(MotionEvent.ACTION_DOWN))
+        generator.generateClick(window, motion(MotionEvent.ACTION_UP))
+    }
+
+    private fun motion(action: Int): MotionEvent =
+        MotionEvent.obtain(0L, 0L, action, TAP_X, TAP_Y, 0)
+
+    private fun finishedSpans(): List<SpanData> {
+        shadowOf(Looper.getMainLooper()).idle()
+        return exporter.finishedSpanItems
+    }
+
+    private fun widgetName(span: SpanData): String? =
+        span.attributes.get(AppIncubatingAttributes.APP_WIDGET_NAME)
+
+    private companion object {
+        const val VIEW_SIZE = 500
+        const val TAP_X = 10f
+        const val TAP_Y = 10f
+    }
+}

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ViewToggleClickTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ViewToggleClickTest.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.hybrid.click
+
+import android.content.Context
+import android.os.Looper
+import android.view.MotionEvent
+import android.view.View
+import android.view.Window
+import android.widget.Button
+import android.widget.CheckBox
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.ATTR_WIDGET_CHECKED
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import io.opentelemetry.semconv.incubating.AppIncubatingAttributes
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Verifies toggle-specific behavior of the View detection path: a switch/checkbox reports its
+ * sibling title as the widget name (instead of the bare class name) and emits its on/off state as
+ * [ATTR_WIDGET_CHECKED].
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [29])
+class ViewToggleClickTest {
+    private lateinit var context: Context
+    private lateinit var exporter: InMemorySpanExporter
+    private lateinit var generator: ClickEventGenerator
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        exporter = InMemorySpanExporter.create()
+        val sdk =
+            OpenTelemetrySdk
+                .builder()
+                .setTracerProvider(
+                    SdkTracerProvider
+                        .builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                        .build(),
+                ).build()
+        generator = ClickEventGenerator(tracer = sdk.getTracer("test"), activeContextWindowMillis = 0)
+    }
+
+    @Test
+    fun `toggle widget name resolves from its sibling title`() {
+        val window = toggleRow(title = "Lock Card Temporarily", checked = false)
+        generator.startTracking(window)
+
+        tap(window)
+
+        assertThat(widgetName(singleSpan())).isEqualTo("Lock Card Temporarily")
+    }
+
+    @Test
+    fun `checked toggle reports checked=true`() {
+        val window = toggleRow(title = "Lock Card Temporarily", checked = true)
+        generator.startTracking(window)
+
+        tap(window)
+
+        assertThat(checkedState(singleSpan())).isTrue()
+    }
+
+    @Test
+    fun `unchecked toggle reports checked=false`() {
+        val window = toggleRow(title = "Lock Card Temporarily", checked = false)
+        generator.startTracking(window)
+
+        tap(window)
+
+        assertThat(checkedState(singleSpan())).isFalse()
+    }
+
+    @Test
+    fun `non-toggle clickable has no checked attribute`() {
+        val button = Button(context).apply { isClickable = true; contentDescription = "Pay" }
+        val root = frameRoot(button)
+        val window = windowOf(root)
+        generator.startTracking(window)
+
+        tap(window)
+
+        assertThat(checkedState(singleSpan())).isNull()
+    }
+
+    @Test
+    fun `checkable that is not a toggle widget has no checked attribute`() {
+        // Mirrors MaterialButton: implements Checkable but is an ordinary button, not a toggle.
+        val checkableButton =
+            object : Button(context), android.widget.Checkable {
+                private var checkedState = false
+
+                override fun setChecked(checked: Boolean) {
+                    checkedState = checked
+                }
+
+                override fun isChecked(): Boolean = checkedState
+
+                override fun toggle() {
+                    checkedState = !checkedState
+                }
+            }.apply { isClickable = true; contentDescription = "OK" }
+        val window = windowOf(frameRoot(checkableButton))
+        generator.startTracking(window)
+
+        tap(window)
+
+        assertThat(checkedState(singleSpan())).isNull()
+    }
+
+    /** Builds a window whose decorView is a row: [ title-column | checkbox ], both filling it. */
+    private fun toggleRow(
+        title: String,
+        checked: Boolean,
+    ): Window {
+        val checkBox = CheckBox(context).apply { isClickable = true; isChecked = checked }
+        val titleColumn =
+            LinearLayout(context).apply {
+                orientation = LinearLayout.VERTICAL
+                addView(TextView(context).apply { text = title })
+            }
+        val root = frameRoot(titleColumn, checkBox)
+        return windowOf(root)
+    }
+
+    /** Stacks [children] in a FrameLayout, each filling it, then measures/lays it out. */
+    private fun frameRoot(vararg children: View): FrameLayout {
+        val root = FrameLayout(context)
+        children.forEach {
+            root.addView(it, FrameLayout.LayoutParams(VIEW_SIZE, VIEW_SIZE))
+        }
+        val spec = View.MeasureSpec.makeMeasureSpec(VIEW_SIZE, View.MeasureSpec.EXACTLY)
+        root.measure(spec, spec)
+        root.layout(0, 0, VIEW_SIZE, VIEW_SIZE)
+        return root
+    }
+
+    private fun windowOf(root: View): Window =
+        mockk<Window>(relaxed = true).also { every { it.decorView } returns root }
+
+    private fun tap(window: Window) {
+        generator.generateClick(window, motion(MotionEvent.ACTION_DOWN))
+        generator.generateClick(window, motion(MotionEvent.ACTION_UP))
+    }
+
+    private fun motion(action: Int): MotionEvent =
+        MotionEvent.obtain(0L, 0L, action, TAP_X, TAP_Y, 0)
+
+    private fun singleSpan(): SpanData {
+        // Drains the deferred checked-state read (a double post) and the span end, which are all
+        // posted with zero delay.
+        shadowOf(Looper.getMainLooper()).idle()
+        return exporter.finishedSpanItems.single()
+    }
+
+    private fun widgetName(span: SpanData): String? =
+        span.attributes.get(AppIncubatingAttributes.APP_WIDGET_NAME)
+
+    private fun checkedState(span: SpanData): Boolean? =
+        span.attributes.get(AttributeKey.booleanKey(ATTR_WIDGET_CHECKED))
+
+    private companion object {
+        const val VIEW_SIZE = 500
+        const val TAP_X = 10f
+        const val TAP_Y = 10f
+    }
+}


### PR DESCRIPTION
Extend hybrid-click to capture clicks across more surfaces and emit toggle state, while keeping the module on public SDK APIs only.

Behavior:
- Track multiple windows simultaneously (Activity + DialogFragment) with per-window gesture state; resolve each tap against the window that received it.
- DialogFragment windows are wrapped via a FragmentManager lifecycle callback (androidx.fragment is compileOnly, lazily/guarded so apps without it neither crash nor pay for it).
- Emit app.widget.checked for genuine toggle widgets (CompoundButton / CheckedTextView only — not the Checkable interface, which MaterialButton implements while being an ordinary button). State is read after the widget's posted PerformClick so it reflects the resulting state, and the span end is scheduled after the read so the attribute is never lost.
- Resolve richer view labels: descend into a clickable container's children (e.g. custom tab items) and, for toggles, into siblings (e.g. a switch's row title) instead of falling back to the class name. Traversal is bounded.

Scope / deliberate limitations:
- Raw dialogs (AlertDialog.Builder().show() not hosted in a DialogFragment) and PopupWindow/PopupMenu are not captured. The only mechanisms to reach those windows require reflection into hidden framework internals (WindowManagerGlobal/DecorView), which is intentionally avoided to keep the module safe for security-sensitive deployments and to pass Android Lint. Host such dialogs in a DialogFragment to have them captured.
- app.widget.checked is View-only; Compose toggle state is not emitted.

Tests: Robolectric + InMemorySpanExporter covering multi-window independence, toggle label/state, and the non-toggle exclusion. Passes the full check (lint, detekt, animalsniffer, api, tests).