### PR TITLE
feat(hybrid-click): capture text-field taps and harden for production

### DIFF
--- a/instrumentation/hybrid-click/DESIGN.md
+++ b/instrumentation/hybrid-click/DESIGN.md
@@ -221,6 +221,26 @@ recomposition (asynchronously), so a reliable post-tap read isn't available thro
 
 ---
 
+## Text fields
+
+Tapping a text field is captured as a `ui.click`, identified by its **label** — never its contents.
+
+- **View** (`EditText`): already clickable, so the View detector finds it. Its label resolves as
+  `contentDescription → hint → class name`; the typed `text` is **never** used.
+- **Compose** (`TextField`/`OutlinedTextField`): these expose no `OnClick` and, in modern Compose,
+  no legacy `SemanticsModifier`, so they are detected via the **semantics tree** — a node carrying a
+  `SemanticsActions.SetText` action. The label prefers the field's `Text` (its label) over any
+  merged `ContentDescription` (usually a decorative leading icon such as "Phone"/"Lock").
+
+**Privacy guarantee.** The entered value is never emitted. On the Compose path the typed value
+(`SemanticsProperties.EditableText`) is read *only* to exclude any label candidate equal to it, and
+fields flagged `SemanticsProperties.Password` fall back to a constant label. Note that
+`app.widget.name` is still derived from visible labels/text generally, which in some apps can be
+dynamic data; deployments with strict data-handling requirements should review what their labels
+contain.
+
+---
+
 ## Window Tracking
 
 A tap is only seen if the window it lands in has its `Window.Callback` wrapped. `hybrid-click`

--- a/instrumentation/hybrid-click/DESIGN.md
+++ b/instrumentation/hybrid-click/DESIGN.md
@@ -225,8 +225,10 @@ recomposition (asynchronously), so a reliable post-tap read isn't available thro
 
 Tapping a text field is captured as a `ui.click`, identified by its **label** — never its contents.
 
-- **View** (`EditText`): already clickable, so the View detector finds it. Its label resolves as
-  `contentDescription → hint → class name`; the typed `text` is **never** used.
+- **View** (`EditText`): a stock `EditText` is focusable but **not** clickable, so the detector
+  treats `EditText` itself as a valid tap target (alongside `isClickable` views). Its label resolves
+  as `contentDescription → hint → class name`; the typed `text` is **never** used, and password
+  `inputType` fields fall back to a constant.
 - **Compose** (`TextField`/`OutlinedTextField`): these expose no `OnClick` and, in modern Compose,
   no legacy `SemanticsModifier`, so they are detected via the **semantics tree** — a node carrying a
   `SemanticsActions.SetText` action. The label prefers the field's `Text` (its label) over any

--- a/instrumentation/hybrid-click/DESIGN.md
+++ b/instrumentation/hybrid-click/DESIGN.md
@@ -233,8 +233,11 @@ Tapping a text field is captured as a `ui.click`, identified by its **label** �
   merged `ContentDescription` (usually a decorative leading icon such as "Phone"/"Lock").
 
 **Privacy guarantee.** The entered value is never emitted. On the Compose path the typed value
-(`SemanticsProperties.EditableText`) is read *only* to exclude any label candidate equal to it, and
-fields flagged `SemanticsProperties.Password` fall back to a constant label. Note that
+(`SemanticsProperties.EditableText`) is read *only* to exclude matching candidates, and — because a
+`VisualTransformation` (card/phone/currency masking) makes the displayed `Text` differ from the raw
+value and bypass that check — the field's `Text` is used as a label **only when the field is empty**
+(when it is the label/placeholder, never input). Fields flagged `SemanticsProperties.Password` fall
+back to a constant label. Note that
 `app.widget.name` is still derived from visible labels/text generally, which in some apps can be
 dynamic data; deployments with strict data-handling requirements should review what their labels
 contain.

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGenerator.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGenerator.kt
@@ -198,9 +198,14 @@ internal class ClickEventGenerator(
             // recorded before the span closes regardless of activeContextWindowMillis.
             mainHandler.post {
                 mainHandler.post {
-                    checkedStateProvider()?.let { checked ->
-                        span.setAttribute(ATTR_WIDGET_CHECKED, checked)
+                    try {
+                        checkedStateProvider()?.let { checked ->
+                            span.setAttribute(ATTR_WIDGET_CHECKED, checked)
+                        }
+                    } catch (throwable: Throwable) {
+                        RumDiagnostics.d { "hybridClick: swallowed error reading toggle state: ${throwable.message}" }
                     }
+                    // Always schedule the end, even if the read above failed, so the span never leaks.
                     mainHandler.postDelayed(endSpan, activeContextWindowMillis)
                 }
             }

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/WindowCallbackWrapper.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/WindowCallbackWrapper.kt
@@ -14,6 +14,7 @@ import android.view.SearchEvent
 import android.view.Window
 import android.view.Window.Callback
 import androidx.annotation.RequiresApi
+import io.opentelemetry.android.common.RumDiagnostics
 
 internal class WindowCallbackWrapper(
     private val callback: Callback,
@@ -21,7 +22,14 @@ internal class WindowCallbackWrapper(
     private val clickEventGenerator: ClickEventGenerator,
 ) : Callback by callback {
     override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
-        clickEventGenerator.generateClick(window, event)
+        // Instrumentation must never affect the host app: any failure while deriving telemetry is
+        // swallowed so the touch is always delivered to the real callback. Critical for the apps
+        // this ships into (e.g. banking), where a dropped touch or crash is unacceptable.
+        try {
+            clickEventGenerator.generateClick(window, event)
+        } catch (throwable: Throwable) {
+            RumDiagnostics.d { "hybridClick: swallowed error during click handling: ${throwable.message}" }
+        }
         return callback.dispatchTouchEvent(event)
     }
 

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetector.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetector.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.node.Owner
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsModifier
+import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getAllSemanticsNodes
 import androidx.compose.ui.semantics.getOrNull
@@ -29,6 +30,25 @@ import java.util.LinkedList
 internal class ComposeTapTargetDetector(
     private val composeLayoutNodeUtil: ComposeLayoutNodeUtil = ComposeLayoutNodeUtil(),
 ) {
+    // Single-tap memo for the merged semantics tree. Resolving one tap reads it several times
+    // (tappable-id collection, the target's own config, ancestor label ranking); building it is the
+    // expensive part. Invalidated at the start of each tap so it never serves a stale tree.
+    // Confined to the main thread, like all touch handling.
+    private var cachedOwner: Owner? = null
+    private var cachedSemanticsNodes: List<SemanticsNode>? = null
+
+    private fun semanticsNodesOf(owner: Owner): List<SemanticsNode> {
+        cachedSemanticsNodes?.let { if (cachedOwner === owner) return it }
+        val nodes =
+            try {
+                owner.semanticsOwner.getAllSemanticsNodes(mergingEnabled = true)
+            } catch (_: Throwable) {
+                emptyList()
+            }
+        cachedOwner = owner
+        cachedSemanticsNodes = nodes
+        return nodes
+    }
     /**
      * Finds the deepest eligible [LayoutNode] at the provided window coordinates.
      */
@@ -98,13 +118,24 @@ internal class ComposeTapTargetDetector(
         x: Float,
         y: Float,
     ): LayoutNode? {
+        // Invalidate the per-tap semantics memo so this tap rebuilds the tree exactly once.
+        cachedOwner = null
+        cachedSemanticsNodes = null
+
+        // Semantics ids of nodes that are tappable but carry no foundation clickable element — most
+        // importantly editable text fields (SetText). In modern Compose, semantics are applied via
+        // the Modifier.Node system and are no longer instances of the legacy SemanticsModifier
+        // interface, so they can't be detected through getModifierInfo(); the semantics tree is the
+        // stable way to find them.
+        val tappableSemanticsIds = collectTappableSemanticsIds(owner)
+
         val queue = LinkedList<LayoutNode>()
         queue.addFirst(owner.root)
         var target: LayoutNode? = null
 
         while (queue.isNotEmpty()) {
             val node = queue.removeFirst()
-            if (node.isPlaced && hitTest(node, x, y)) {
+            if (node.isPlaced && hitTest(node, x, y, tappableSemanticsIds)) {
                 target = node
             }
             queue.addAll(node.zSortedChildren.asMutableList())
@@ -113,30 +144,52 @@ internal class ComposeTapTargetDetector(
     }
 
     /**
+     * Collects semantics ids of nodes exposing an `OnClick` or `SetText` action (clickables and
+     * editable text fields). Empty if the semantics tree can't be read.
+     */
+    private fun collectTappableSemanticsIds(owner: Owner): Set<Int> =
+        try {
+            semanticsNodesOf(owner)
+                .filter { node ->
+                    node.config.contains(SemanticsActions.OnClick) ||
+                        node.config.contains(SemanticsActions.SetText)
+                }.map { it.id }
+                .toSet()
+        } catch (_: Throwable) {
+            emptySet()
+        }
+
+    /**
      * Checks coordinate bounds and clickability constraints.
      */
     private fun hitTest(
         node: LayoutNode,
         x: Float,
         y: Float,
+        tappableSemanticsIds: Set<Int>,
     ): Boolean {
         val bounded =
             composeLayoutNodeUtil.getLayoutNodeBoundsInWindow(node)?.let { bounds ->
                 x >= bounds.left && x <= bounds.right && y >= bounds.top && y <= bounds.bottom
             } == true
 
-        return bounded && isValidClickTarget(node)
+        return bounded && (isValidClickTarget(node) || node.semanticsId in tappableSemanticsIds)
     }
 
     /**
-     * Determines whether node semantics/modifiers represent a clickable element.
+     * Determines whether node semantics/modifiers represent a tappable element.
+     *
+     * Besides clickable elements, this also matches editable text fields (nodes exposing
+     * [SemanticsActions.SetText]). Tapping a `TextField` is a focus/edit gesture, not an `OnClick`,
+     * so without this check field taps would never produce a span. Only the field's label is later
+     * used for telemetry — the typed value ([SemanticsProperties.EditableText]) is never read.
      */
     private fun isValidClickTarget(node: LayoutNode): Boolean {
         for (info in node.getModifierInfo()) {
             val modifier = info.modifier
             if (modifier is SemanticsModifier) {
                 with(modifier.semanticsConfiguration) {
-                    if (contains(SemanticsActions.OnClick)) {
+                    if (contains(SemanticsActions.OnClick) || contains(SemanticsActions.SetText)) {
                         return true
                     }
                 }
@@ -164,6 +217,10 @@ internal class ComposeTapTargetDetector(
      */
     @Suppress("unused") // Used reflectively by ClickEventGenerator
     private fun nodeToLabel(node: LayoutNode): String {
+        mergedConfigFor(node)?.takeIf { it.contains(SemanticsActions.SetText) }?.let { fieldConfig ->
+            return editableFieldLabel(node, fieldConfig)
+        }
+
         val semanticsLabel = getMergedSemanticsLabel(node) ?: getNodeName(node)
         val childText = extractTextFromChildren(node)
         val className = getModifierClassName(node)
@@ -174,6 +231,58 @@ internal class ComposeTapTargetDetector(
             fallback = nodeId(node),
         )
     }
+
+    /**
+     * Resolves a privacy-safe label for an editable text field.
+     *
+     * The field's label (its `Text`) is preferred over the merged ContentDescription, which is
+     * usually a decorative leading/trailing icon ("Phone"/"Lock"). The typed value
+     * ([SemanticsProperties.EditableText]) is **never emitted**: it is read only to exclude any
+     * candidate that equals it, and password-flagged fields fall back to a constant rather than risk
+     * surfacing entered text. This is a hard guarantee for the apps this ships into (e.g. banking).
+     */
+    private fun editableFieldLabel(
+        node: LayoutNode,
+        fieldConfig: SemanticsConfiguration,
+    ): String {
+        val typedValue =
+            try {
+                fieldConfig.getOrNull(SemanticsProperties.EditableText)?.text
+            } catch (_: Throwable) {
+                null
+            }
+        val isPassword =
+            try {
+                fieldConfig.contains(SemanticsProperties.Password)
+            } catch (_: Throwable) {
+                false
+            }
+
+        // A candidate is only usable if it is non-blank and is not the field's current value.
+        fun safe(candidate: String?): String? =
+            candidate?.takeIf { it.isNotBlank() && it != typedValue }
+
+        val labelText = fieldConfig.getOrNull(SemanticsProperties.Text)?.firstOrNull()?.text
+        val contentDescription = fieldConfig.getOrNull(SemanticsProperties.ContentDescription)?.firstOrNull()
+        val resolved = safe(labelText) ?: safe(contentDescription)
+
+        return resolved
+            ?: if (isPassword) PASSWORD_FIELD_LABEL else (getModifierClassName(node) ?: nodeId(node))
+    }
+
+    /**
+     * Returns the merged [SemanticsConfiguration] for [node] from the semantics tree, or `null` if
+     * unavailable. Used to inspect a node's own semantics (e.g. whether it is an editable field).
+     */
+    private fun mergedConfigFor(node: LayoutNode): SemanticsConfiguration? =
+        try {
+            val owner = node.owner ?: return null
+            semanticsNodesOf(owner)
+                .firstOrNull { it.id == node.semanticsId }
+                ?.config
+        } catch (_: Throwable) {
+            null
+        }
 
     /**
      * Extracts text from child Text composables (e.g., "Go to API Test Screen" from Button { Text(...) }).
@@ -231,7 +340,7 @@ internal class ComposeTapTargetDetector(
 
             var bestRank = Int.MAX_VALUE
             var bestLabel: String? = null
-            for (semanticsNode in owner.semanticsOwner.getAllSemanticsNodes(mergingEnabled = true)) {
+            for (semanticsNode in semanticsNodesOf(owner)) {
                 val rank = rankBySemanticsId[semanticsNode.id]
                 if (rank != null) {
                     val semanticsLabel = semanticsLabelFrom(semanticsNode.config)
@@ -335,5 +444,8 @@ internal class ComposeTapTargetDetector(
             "androidx.compose.foundation.CombinedClickableElement"
         private const val CLASS_NAME_TOGGLEABLE_ELEMENT =
             "androidx.compose.foundation.selection.ToggleableElement"
+
+        /** Safe placeholder used when a password field has no usable non-value label. */
+        private const val PASSWORD_FIELD_LABEL = "password field"
     }
 }

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetector.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetector.kt
@@ -60,9 +60,15 @@ internal class ComposeTapTargetDetector(
 
     /**
      * Resolves a stable display name for telemetry from node semantics/modifier metadata.
+     *
+     * Editable fields are routed through the same privacy-safe path as [nodeToLabel] so this can
+     * never surface typed content, even though only the label currently reaches a span attribute.
      */
     internal fun nodeToName(node: LayoutNode): String =
         try {
+            mergedConfigFor(node)?.takeIf { it.contains(SemanticsActions.SetText) }?.let { fieldConfig ->
+                return editableFieldLabel(node, fieldConfig)
+            }
             getMergedSemanticsLabel(node)
                 ?: getNodeName(node)
                 ?: getModifierClassName(node)
@@ -241,7 +247,7 @@ internal class ComposeTapTargetDetector(
      * candidate that equals it, and password-flagged fields fall back to a constant rather than risk
      * surfacing entered text. This is a hard guarantee for the apps this ships into (e.g. banking).
      */
-    private fun editableFieldLabel(
+    internal fun editableFieldLabel(
         node: LayoutNode,
         fieldConfig: SemanticsConfiguration,
     ): String {

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetector.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetector.kt
@@ -257,17 +257,28 @@ internal class ComposeTapTargetDetector(
             } catch (_: Throwable) {
                 false
             }
+        val hasContent = !typedValue.isNullOrEmpty()
 
         // A candidate is only usable if it is non-blank and is not the field's current value.
         fun safe(candidate: String?): String? =
             candidate?.takeIf { it.isNotBlank() && it != typedValue }
 
-        val labelText = fieldConfig.getOrNull(SemanticsProperties.Text)?.firstOrNull()?.text
+        // `Text` on a TextField can carry the *displayed* value, which under a VisualTransformation
+        // (card / phone / currency masks) differs character-for-character from the raw EditableText
+        // and would slip past the equality guard above. So only trust `Text` when the field is empty
+        // — then it is the label/placeholder, never user input. contentDescription is the field's
+        // own accessibility label or a decorative icon ("Phone"/"Lock"), never the typed value.
+        val labelText = if (hasContent) null else fieldConfig.getOrNull(SemanticsProperties.Text)?.firstOrNull()?.text
         val contentDescription = fieldConfig.getOrNull(SemanticsProperties.ContentDescription)?.firstOrNull()
-        val resolved = safe(labelText) ?: safe(contentDescription)
 
-        return resolved
-            ?: if (isPassword) PASSWORD_FIELD_LABEL else (getModifierClassName(node) ?: nodeId(node))
+        if (isPassword) {
+            // Never let a password field surface anything but its static label.
+            return safe(labelText) ?: PASSWORD_FIELD_LABEL
+        }
+
+        return safe(labelText)
+            ?: safe(contentDescription)
+            ?: (getModifierClassName(node) ?: nodeId(node))
     }
 
     /**

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/view/ViewTapTargetDetector.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/view/ViewTapTargetDetector.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.CheckedTextView
 import android.widget.CompoundButton
+import android.widget.EditText
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.LabelResolver
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.SOURCE_VIEW
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.TapTarget
@@ -110,6 +111,18 @@ internal class ViewTapTargetDetector : TapTargetDetector {
 
     private fun viewToLabel(view: View): String {
         val contentDescription = view.contentDescription?.toString()
+
+        // Editable text fields must never expose their typed content (it may be PII or a password).
+        // Resolve from the accessibility label, then the hint, then the class name.
+        if (view is EditText) {
+            return LabelResolver.resolve(
+                contentDescription = contentDescription,
+                text = view.hint?.toString(),
+                className = view.javaClass.simpleName,
+                fallback = view.id.toString(),
+            )
+        }
+
         val text = (view as? android.widget.TextView)?.text?.toString()
 
         val resolvedLabel =

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/view/ViewTapTargetDetector.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/view/ViewTapTargetDetector.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android.instrumentation.hybrid.click.view
 
+import android.text.InputType
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CheckedTextView
@@ -70,7 +71,16 @@ internal class ViewTapTargetDetector : TapTargetDetector {
 
     private fun isToggle(view: View): Boolean = view is CompoundButton || view is CheckedTextView
 
-    private fun isValidClickTarget(view: View): Boolean = view.isClickable && view.isVisible
+    private fun isValidClickTarget(view: View): Boolean =
+        view.isVisible && (view.isClickable || view is EditText)
+
+    private fun isPasswordField(view: EditText): Boolean {
+        val variation = view.inputType and InputType.TYPE_MASK_VARIATION
+        return variation == InputType.TYPE_TEXT_VARIATION_PASSWORD ||
+            variation == InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD ||
+            variation == InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD ||
+            variation == InputType.TYPE_NUMBER_VARIATION_PASSWORD
+    }
 
     private fun handleViewGroup(
         view: ViewGroup,
@@ -113,8 +123,14 @@ internal class ViewTapTargetDetector : TapTargetDetector {
         val contentDescription = view.contentDescription?.toString()
 
         // Editable text fields must never expose their typed content (it may be PII or a password).
-        // Resolve from the accessibility label, then the hint, then the class name.
+        // Resolve from the accessibility label, then the hint, then the class name. Password fields
+        // fall back to a constant rather than the class name, mirroring the Compose path.
         if (view is EditText) {
+            if (isPasswordField(view)) {
+                return contentDescription?.takeIf { it.isNotBlank() }
+                    ?: view.hint?.toString()?.takeIf { it.isNotBlank() }
+                    ?: PASSWORD_FIELD_LABEL
+            }
             return LabelResolver.resolve(
                 contentDescription = contentDescription,
                 text = view.hint?.toString(),
@@ -216,5 +232,8 @@ internal class ViewTapTargetDetector : TapTargetDetector {
     private companion object {
         /** Upper bound on nodes scanned when resolving a label, to keep traversal cheap. */
         const val MAX_LABEL_SEARCH_NODES = 100
+
+        /** Safe placeholder for a password field with no usable label/hint. */
+        const val PASSWORD_FIELD_LABEL = "password field"
     }
 }

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ViewEditTextClickTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ViewEditTextClickTest.kt
@@ -93,6 +93,23 @@ class ViewEditTextClickTest {
         assertThat(name).doesNotContain("hunter2")
     }
 
+    @Test
+    fun `default edit text without explicit clickable is still detected`() {
+        // Real-world EditText defaults to focusable, not clickable; the detector must still find it.
+        val window =
+            windowOf(
+                EditText(context).apply {
+                    hint = "Mobile Number"
+                    setText("9876543210")
+                },
+            )
+        generator.startTracking(window)
+
+        tap(window)
+
+        assertThat(widgetName(singleSpan())).isEqualTo("Mobile Number")
+    }
+
     private fun windowOf(field: View): Window {
         val root = FrameLayout(context).apply { addView(field, FrameLayout.LayoutParams(VIEW_SIZE, VIEW_SIZE)) }
         val spec = View.MeasureSpec.makeMeasureSpec(VIEW_SIZE, View.MeasureSpec.EXACTLY)

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ViewEditTextClickTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ViewEditTextClickTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.hybrid.click
+
+import android.content.Context
+import android.os.Looper
+import android.view.MotionEvent
+import android.view.View
+import android.view.Window
+import android.widget.EditText
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import io.opentelemetry.semconv.incubating.AppIncubatingAttributes
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Verifies that tapping an editable text field is captured by its label and never leaks the typed
+ * content (which may be PII or a password).
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [29])
+class ViewEditTextClickTest {
+    private lateinit var context: Context
+    private lateinit var exporter: InMemorySpanExporter
+    private lateinit var generator: ClickEventGenerator
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        exporter = InMemorySpanExporter.create()
+        val sdk =
+            OpenTelemetrySdk
+                .builder()
+                .setTracerProvider(
+                    SdkTracerProvider
+                        .builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                        .build(),
+                ).build()
+        generator = ClickEventGenerator(tracer = sdk.getTracer("test"), activeContextWindowMillis = 0)
+    }
+
+    @Test
+    fun `edit text uses its hint as the label, never the typed text`() {
+        val window =
+            windowOf(
+                EditText(context).apply {
+                    isClickable = true
+                    hint = "Mobile Number"
+                    setText("9876543210")
+                },
+            )
+        generator.startTracking(window)
+
+        tap(window)
+
+        assertThat(widgetName(singleSpan())).isEqualTo("Mobile Number")
+    }
+
+    @Test
+    fun `edit text prefers content description over hint`() {
+        val window =
+            windowOf(
+                EditText(context).apply {
+                    isClickable = true
+                    contentDescription = "Password field"
+                    hint = "Password"
+                    setText("hunter2")
+                },
+            )
+        generator.startTracking(window)
+
+        tap(window)
+
+        val name = widgetName(singleSpan())
+        assertThat(name).isEqualTo("Password field")
+        assertThat(name).doesNotContain("hunter2")
+    }
+
+    private fun windowOf(field: View): Window {
+        val root = FrameLayout(context).apply { addView(field, FrameLayout.LayoutParams(VIEW_SIZE, VIEW_SIZE)) }
+        val spec = View.MeasureSpec.makeMeasureSpec(VIEW_SIZE, View.MeasureSpec.EXACTLY)
+        root.measure(spec, spec)
+        root.layout(0, 0, VIEW_SIZE, VIEW_SIZE)
+        return mockk<Window>(relaxed = true).also { every { it.decorView } returns root }
+    }
+
+    private fun tap(window: Window) {
+        generator.generateClick(window, motion(MotionEvent.ACTION_DOWN))
+        generator.generateClick(window, motion(MotionEvent.ACTION_UP))
+    }
+
+    private fun motion(action: Int): MotionEvent = MotionEvent.obtain(0L, 0L, action, TAP, TAP, 0)
+
+    private fun singleSpan(): SpanData {
+        shadowOf(Looper.getMainLooper()).idle()
+        return exporter.finishedSpanItems.single()
+    }
+
+    private fun widgetName(span: SpanData): String? =
+        span.attributes.get(AppIncubatingAttributes.APP_WIDGET_NAME)
+
+    private companion object {
+        const val VIEW_SIZE = 500
+        const val TAP = 10f
+    }
+}

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/WindowCallbackWrapperTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/WindowCallbackWrapperTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.hybrid.click
+
+import android.view.MotionEvent
+import android.view.Window
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class WindowCallbackWrapperTest {
+    /**
+     * Locks in the production-safety guarantee: a failure while deriving telemetry must never stop
+     * the touch from reaching the real callback.
+     */
+    @Test
+    fun `forwards the touch to the delegate even when click handling throws`() {
+        val callback = mockk<Window.Callback>(relaxed = true)
+        val window = mockk<Window>(relaxed = true)
+        val generator = mockk<ClickEventGenerator>()
+        val event = mockk<MotionEvent>(relaxed = true)
+        every { generator.generateClick(window, event) } throws RuntimeException("boom")
+        every { callback.dispatchTouchEvent(event) } returns true
+
+        val wrapper = WindowCallbackWrapper(callback, window, generator)
+        val result = wrapper.dispatchTouchEvent(event)
+
+        assertThat(result).isTrue()
+        verify(exactly = 1) { callback.dispatchTouchEvent(event) }
+    }
+}

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetectorTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetectorTest.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsModifier
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.text.AnnotatedString
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -79,6 +80,81 @@ internal class ComposeTapTargetDetectorTest {
 
         val name = detector.nodeToName(mockNode)
         assertThat(name).isNotBlank()
+    }
+
+    @Test
+    fun `editable field uses its label when empty`() {
+        val label =
+            detector.editableFieldLabel(
+                fieldNode(),
+                fieldConfig(editable = "", text = "Mobile Number"),
+            )
+        assertThat(label).isEqualTo("Mobile Number")
+    }
+
+    @Test
+    fun `editable field with masked content never emits the displayed value`() {
+        val raw = "4111111111111111"
+        val masked = "4111 1111 1111 1111"
+        val label =
+            detector.editableFieldLabel(
+                fieldNode(),
+                fieldConfig(editable = raw, text = masked),
+            )
+        assertThat(label).isNotEqualTo(masked)
+        assertThat(label).isNotEqualTo(raw)
+    }
+
+    @Test
+    fun `editable field excludes a content description equal to the typed value`() {
+        val value = "john@example.com"
+        val label =
+            detector.editableFieldLabel(
+                fieldNode(),
+                fieldConfig(editable = value, contentDescription = value),
+            )
+        assertThat(label).isNotEqualTo(value)
+    }
+
+    @Test
+    fun `empty password field uses its label`() {
+        val label =
+            detector.editableFieldLabel(
+                fieldNode(),
+                fieldConfig(editable = "", text = "Password", password = true),
+            )
+        assertThat(label).isEqualTo("Password")
+    }
+
+    @Test
+    fun `password field with content falls back to a constant`() {
+        val secret = "s3cr3t"
+        val label =
+            detector.editableFieldLabel(
+                fieldNode(),
+                fieldConfig(editable = secret, text = "••••••", contentDescription = "Lock", password = true),
+            )
+        assertThat(label).isEqualTo("password field")
+        assertThat(label).isNotEqualTo(secret)
+    }
+
+    /** A LayoutNode whose only role is the class-name/hashCode fallback path. */
+    private fun fieldNode(): LayoutNode =
+        mockkClass(LayoutNode::class).also { every { it.getModifierInfo() } returns listOf() }
+
+    private fun fieldConfig(
+        editable: String,
+        text: String? = null,
+        contentDescription: String? = null,
+        password: Boolean = false,
+    ): SemanticsConfiguration {
+        every { semanticsConfiguration.getOrNull(eq(SemanticsProperties.EditableText)) } returns AnnotatedString(editable)
+        every { semanticsConfiguration.contains(SemanticsProperties.Password) } returns password
+        every { semanticsConfiguration.getOrNull(eq(SemanticsProperties.Text)) } returns
+            text?.let { listOf(AnnotatedString(it)) }
+        every { semanticsConfiguration.getOrNull(eq(SemanticsProperties.ContentDescription)) } returns
+            contentDescription?.let { listOf(it) }
+        return semanticsConfiguration
     }
 
     private fun createMockLayoutNode(


### PR DESCRIPTION
- Compose: detect editable TextFields via the semantics tree (SemanticsActions.SetText), since modern Compose no longer exposes the legacy SemanticsModifier; label prefers the field label over a decorative leading-icon contentDescription.
- View: EditText label resolves as contentDescription -> hint -> class name, never the typed text.
- Privacy: the typed value (Compose EditableText / View text) is never emitted; password-flagged fields fall back to a constant label.
- Reliability: isolate the touch path so a telemetry failure can never crash the app or drop a touch.
- Performance: build the merged semantics tree once per tap (was up to 3x).
- Docs: document text-field capture and the privacy guarantee.