### PR TITLE
feat(navigation): emit navigation.trigger for nav2 and view; fix nav2…

### DIFF
--- a/instrumentation/navigation-common/api/navigation-common.api
+++ b/instrumentation/navigation-common/api/navigation-common.api
@@ -84,3 +84,18 @@ public final class io/opentelemetry/android/instrumentation/navigation/common/mo
 	public static fun values ()[Lio/opentelemetry/android/instrumentation/navigation/common/models/NavigationTransitionType;
 }
 
+public final class io/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger : java/lang/Enum {
+	public static final field BACK_PRESS Lio/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger;
+	public static final field BACK_PRESS_SIGNAL_TTL_NANOS J
+	public static final field Companion Lio/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger$Companion;
+	public static final field PROGRAMMATIC Lio/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger;
+	public static final field UNKNOWN Lio/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lio/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger;
+	public static fun values ()[Lio/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger;
+}
+
+public final class io/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger$Companion {
+}
+

--- a/instrumentation/navigation-common/api/navigation-common.api
+++ b/instrumentation/navigation-common/api/navigation-common.api
@@ -86,16 +86,11 @@ public final class io/opentelemetry/android/instrumentation/navigation/common/mo
 
 public final class io/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger : java/lang/Enum {
 	public static final field BACK_PRESS Lio/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger;
-	public static final field BACK_PRESS_SIGNAL_TTL_NANOS J
-	public static final field Companion Lio/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger$Companion;
 	public static final field PROGRAMMATIC Lio/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger;
 	public static final field UNKNOWN Lio/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getValue ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lio/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger;
 	public static fun values ()[Lio/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger;
-}
-
-public final class io/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger$Companion {
 }
 

--- a/instrumentation/navigation-common/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger.kt
+++ b/instrumentation/navigation-common/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger.kt
@@ -25,14 +25,4 @@ enum class NavigationTrigger(
 
     /** A forward transition ([NavigationTransitionType.PUSH]/[NavigationTransitionType.REPLACE]). */
     UNKNOWN("unknown"),
-    ;
-
-    companion object {
-        /**
-         * How long a recorded back press stays eligible to be attributed to the next pop. A pop
-         * that arrives later than this is treated as [PROGRAMMATIC], guarding against a stale signal
-         * (e.g. a back press that did not actually move the back stack) being misattributed.
-         */
-        const val BACK_PRESS_SIGNAL_TTL_NANOS: Long = 1_000_000_000L
-    }
 }

--- a/instrumentation/navigation-common/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger.kt
+++ b/instrumentation/navigation-common/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/common/models/NavigationTrigger.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.navigation.common.models
+
+/**
+ * What caused a navigation transition, written to the `navigation.trigger` span attribute.
+ *
+ * Shared by every navigation collector (Nav2, Nav3, View) so the attribute contract is defined in
+ * exactly one place. Only a [NavigationTransitionType.POP] that follows a recent back press is
+ * reported as [BACK_PRESS]; other pops are [PROGRAMMATIC] and forward transitions are [UNKNOWN].
+ *
+ * @property value Stable string written to the `navigation.trigger` span attribute.
+ */
+enum class NavigationTrigger(
+    val value: String,
+) {
+    /** A [NavigationTransitionType.POP] attributed to a recent back press. */
+    BACK_PRESS("back_press"),
+
+    /** A pop not preceded by a back press, i.e. a code-driven `popBackStack`/`navigateUp`. */
+    PROGRAMMATIC("programmatic"),
+
+    /** A forward transition ([NavigationTransitionType.PUSH]/[NavigationTransitionType.REPLACE]). */
+    UNKNOWN("unknown"),
+    ;
+
+    companion object {
+        /**
+         * How long a recorded back press stays eligible to be attributed to the next pop. A pop
+         * that arrives later than this is treated as [PROGRAMMATIC], guarding against a stale signal
+         * (e.g. a back press that did not actually move the back stack) being misattributed.
+         */
+        const val BACK_PRESS_SIGNAL_TTL_NANOS: Long = 1_000_000_000L
+    }
+}

--- a/instrumentation/navigation-compose-nav2/api/navigation-compose-nav2.api
+++ b/instrumentation/navigation-compose-nav2/api/navigation-compose-nav2.api
@@ -8,5 +8,6 @@ public final class io/opentelemetry/android/instrumentation/navigation/compose/n
 
 public final class io/opentelemetry/android/instrumentation/navigation/compose/nav2/VunetNav2ObserverKt {
 	public static final fun VunetNav2Observer (Landroidx/navigation/NavController;Landroidx/compose/runtime/Composer;I)V
+	public static final fun rememberVunetOnBack (Landroidx/navigation/NavController;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)Lkotlin/jvm/functions/Function0;
 }
 

--- a/instrumentation/navigation-compose-nav2/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/ComposeNav2Collector.kt
+++ b/instrumentation/navigation-compose-nav2/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/ComposeNav2Collector.kt
@@ -16,7 +16,14 @@ import io.opentelemetry.android.instrumentation.navigation.common.models.Navigat
 import io.opentelemetry.android.instrumentation.navigation.common.models.NavigationNodeType
 import io.opentelemetry.android.instrumentation.navigation.common.models.NavigationTransitionCandidate
 import io.opentelemetry.android.instrumentation.navigation.common.models.NavigationTransitionType
+import io.opentelemetry.android.instrumentation.navigation.common.models.NavigationTrigger
 
+/**
+ * Threading contract: this collector is not internally synchronized. `onDestinationChanged` is
+ * delivered by the Navigation library on the main thread, and [recordBackPress] is expected to be
+ * called from the same main thread (it is wired through `rememberVunetOnBack`, a Compose callback).
+ * Driving it from other threads concurrently is unsupported.
+ */
 internal class ComposeNav2Collector(
     openTelemetryRum: OpenTelemetryRum,
     private val destinationFilter: (NavDestination) -> Boolean = ComposeNav2DestinationFilter::shouldIgnore,
@@ -85,12 +92,15 @@ internal class ComposeNav2Collector(
     }
 
     /**
-     * Classifies the transition into [destinationId] using our tracked stack:
+     * Classifies the transition into [destinationId] using our tracked stack and the live entry
+     * directly beneath the new top ([NavController.previousBackStackEntry]):
      * - the first destination is a [NavigationTransitionType.PUSH];
-     * - returning to a destination already on the stack is a [NavigationTransitionType.POP];
-     * - a new destination is a [NavigationTransitionType.PUSH] when the previous top is still
-     *   beneath it (live [NavController.previousBackStackEntry]), otherwise a
-     *   [NavigationTransitionType.REPLACE].
+     * - if the previous top is now the entry beneath [destinationId], the stack grew, so it is a
+     *   [NavigationTransitionType.PUSH] — this is checked first so that re-pushing a destination
+     *   that already appears elsewhere on the stack (e.g. A → B → A) is not mistaken for a pop;
+     * - otherwise, returning to a destination already on the stack is a
+     *   [NavigationTransitionType.POP];
+     * - any other new destination is a [NavigationTransitionType.REPLACE].
      */
     private fun inferTransitionType(
         controller: NavController,
@@ -99,17 +109,23 @@ internal class ComposeNav2Collector(
         if (destinationIdStack.isEmpty()) {
             return NavigationTransitionType.PUSH
         }
+        val liveEntryBelowTopId = previousEntryIdProvider(controller)
+        if (liveEntryBelowTopId != null && liveEntryBelowTopId == destinationIdStack.last()) {
+            // The previous top is still directly below the new top: the back stack grew by one.
+            return NavigationTransitionType.PUSH
+        }
         if (destinationIdStack.contains(destinationId)) {
             return NavigationTransitionType.POP
         }
-        val liveEntryBelowTopId = previousEntryIdProvider(controller)
-        return if (liveEntryBelowTopId != null && liveEntryBelowTopId == destinationIdStack.last()) {
-            NavigationTransitionType.PUSH
-        } else {
-            NavigationTransitionType.REPLACE
-        }
+        return NavigationTransitionType.REPLACE
     }
 
+    /**
+     * Updates [destinationIdStack] to reflect the applied [transitionType]. For a
+     * [NavigationTransitionType.POP] the entries above [destinationId] are unwound while
+     * [destinationId] itself is intentionally kept as the new top (it is the screen the user
+     * returned to).
+     */
     private fun applyTransition(
         transitionType: NavigationTransitionType,
         destinationId: Int,
@@ -117,6 +133,7 @@ internal class ComposeNav2Collector(
         when (transitionType) {
             NavigationTransitionType.PUSH -> destinationIdStack.addLast(destinationId)
             NavigationTransitionType.POP -> {
+                // Unwind everything above destinationId, leaving it as the new top.
                 while (destinationIdStack.isNotEmpty() && destinationIdStack.last() != destinationId) {
                     destinationIdStack.removeLast()
                 }
@@ -158,20 +175,10 @@ internal class ComposeNav2Collector(
     private fun consumeBackPressSignal(): Boolean {
         val backPressTimestampNanos = pendingBackPressTimestampNanos ?: return false
         pendingBackPressTimestampNanos = null
-        return clock.now() - backPressTimestampNanos <= BACK_PRESS_SIGNAL_TTL_NANOS
-    }
-
-    private enum class NavigationTrigger(
-        val value: String,
-    ) {
-        BACK_PRESS("back_press"),
-        PROGRAMMATIC("programmatic"),
-        UNKNOWN("unknown"),
+        return clock.now() - backPressTimestampNanos <= NavigationTrigger.BACK_PRESS_SIGNAL_TTL_NANOS
     }
 
     companion object {
-        private const val BACK_PRESS_SIGNAL_TTL_NANOS: Long = 1_000_000_000L
-
         /**
          * Reads the id of the destination directly beneath the current top using the public,
          * version-stable [NavController.previousBackStackEntry] (which reflects the live back stack

--- a/instrumentation/navigation-compose-nav2/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/ComposeNav2Collector.kt
+++ b/instrumentation/navigation-compose-nav2/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/ComposeNav2Collector.kt
@@ -21,13 +21,29 @@ internal class ComposeNav2Collector(
     openTelemetryRum: OpenTelemetryRum,
     private val destinationFilter: (NavDestination) -> Boolean = ComposeNav2DestinationFilter::shouldIgnore,
     private val destinationNameExtractor: (NavDestination) -> String = ComposeNav2DestinationNameExtractor::extract,
-    private val backStackSizeProvider: (NavController) -> Int? = ::readBackStackSize,
+    private val previousEntryIdProvider: (NavController) -> Int? = ::readPreviousEntryId,
 ) : NavController.OnDestinationChangedListener {
     private val emitter: NavigationSpanEmitter =
         NavigationSpanEmitter(openTelemetryRum.openTelemetry.getTracer(INSTRUMENTATION_SCOPE))
     private val clock = openTelemetryRum.clock
     private var currentVisibleNode: NavigationNode? = null
-    private var previousBackStackSize: Int? = null
+
+    /**
+     * Our own view of the destination back stack, keyed by [NavDestination.id]. Maintained from the
+     * sequence of destination-changed callbacks instead of reading the (version-specific, R8-fragile)
+     * private `backQueue` field, so push/pop/replace inference works regardless of the Navigation
+     * library version the host app resolves.
+     */
+    private val destinationIdStack: ArrayDeque<Int> = ArrayDeque()
+    private var pendingBackPressTimestampNanos: Long? = null
+
+    /**
+     * Records that a back press just occurred so the next [NavigationTransitionType.POP] can be
+     * attributed to [NavigationTrigger.BACK_PRESS]. Wire this through [rememberVunetOnBack].
+     */
+    fun recordBackPress() {
+        pendingBackPressTimestampNanos = clock.now()
+    }
 
     override fun onDestinationChanged(
         controller: NavController,
@@ -38,56 +54,130 @@ internal class ComposeNav2Collector(
             return
         }
 
+        val destinationId = destination.id
+        if (destinationIdStack.lastOrNull() == destinationId) {
+            // Same destination re-dispatched (e.g. recomposition); nothing navigational changed.
+            return
+        }
+
+        val transitionType = inferTransitionType(controller, destinationId)
+        applyTransition(transitionType, destinationId)
+
         val destinationNode =
             NavigationNode(
                 type = NavigationNodeType.COMPOSE_ROUTE,
                 name = destinationNameExtractor(destination),
             )
-        val source = currentVisibleNode
-        if (source != null && source == destinationNode) {
-            previousBackStackSize = backStackSizeProvider(controller)
-            return
-        }
-
-        val currentBackStackSize = backStackSizeProvider(controller)
-        val transitionType = inferTransitionType(previousBackStackSize, currentBackStackSize, source != null)
+        val navigationTrigger = resolveTrigger(transitionType)
 
         emitter.emit(
             NavigationTransitionCandidate(
-                source = source,
+                source = currentVisibleNode,
                 destination = destinationNode,
                 transitionType = transitionType,
                 entryType = NavigationEntryType.INTERNAL,
                 timestampNanos = clock.now(),
             ),
+            navigationTrigger = navigationTrigger.value,
         )
 
         currentVisibleNode = destinationNode
-        previousBackStackSize = currentBackStackSize
     }
 
+    /**
+     * Classifies the transition into [destinationId] using our tracked stack:
+     * - the first destination is a [NavigationTransitionType.PUSH];
+     * - returning to a destination already on the stack is a [NavigationTransitionType.POP];
+     * - a new destination is a [NavigationTransitionType.PUSH] when the previous top is still
+     *   beneath it (live [NavController.previousBackStackEntry]), otherwise a
+     *   [NavigationTransitionType.REPLACE].
+     */
     private fun inferTransitionType(
-        oldSize: Int?,
-        newSize: Int?,
-        hasSource: Boolean,
+        controller: NavController,
+        destinationId: Int,
     ): NavigationTransitionType {
-        if (oldSize != null && newSize != null) {
-            return when {
-                newSize > oldSize -> NavigationTransitionType.PUSH
-                newSize < oldSize -> NavigationTransitionType.POP
-                else -> NavigationTransitionType.REPLACE
+        if (destinationIdStack.isEmpty()) {
+            return NavigationTransitionType.PUSH
+        }
+        if (destinationIdStack.contains(destinationId)) {
+            return NavigationTransitionType.POP
+        }
+        val liveEntryBelowTopId = previousEntryIdProvider(controller)
+        return if (liveEntryBelowTopId != null && liveEntryBelowTopId == destinationIdStack.last()) {
+            NavigationTransitionType.PUSH
+        } else {
+            NavigationTransitionType.REPLACE
+        }
+    }
+
+    private fun applyTransition(
+        transitionType: NavigationTransitionType,
+        destinationId: Int,
+    ) {
+        when (transitionType) {
+            NavigationTransitionType.PUSH -> destinationIdStack.addLast(destinationId)
+            NavigationTransitionType.POP -> {
+                while (destinationIdStack.isNotEmpty() && destinationIdStack.last() != destinationId) {
+                    destinationIdStack.removeLast()
+                }
+            }
+
+            NavigationTransitionType.REPLACE -> {
+                if (destinationIdStack.isNotEmpty()) {
+                    destinationIdStack.removeLast()
+                }
+                destinationIdStack.addLast(destinationId)
             }
         }
-        return if (hasSource) NavigationTransitionType.REPLACE else NavigationTransitionType.PUSH
+    }
+
+    /**
+     * Attributes a transition to a [NavigationTrigger]. Only a [NavigationTransitionType.POP]
+     * that follows a recent [recordBackPress] is reported as [NavigationTrigger.BACK_PRESS];
+     * other pops are [NavigationTrigger.PROGRAMMATIC] and forward transitions are
+     * [NavigationTrigger.UNKNOWN].
+     */
+    private fun resolveTrigger(transitionType: NavigationTransitionType): NavigationTrigger =
+        when (transitionType) {
+            NavigationTransitionType.POP -> {
+                if (consumeBackPressSignal()) {
+                    NavigationTrigger.BACK_PRESS
+                } else {
+                    NavigationTrigger.PROGRAMMATIC
+                }
+            }
+
+            NavigationTransitionType.PUSH,
+            NavigationTransitionType.REPLACE,
+            -> {
+                pendingBackPressTimestampNanos = null
+                NavigationTrigger.UNKNOWN
+            }
+        }
+
+    private fun consumeBackPressSignal(): Boolean {
+        val backPressTimestampNanos = pendingBackPressTimestampNanos ?: return false
+        pendingBackPressTimestampNanos = null
+        return clock.now() - backPressTimestampNanos <= BACK_PRESS_SIGNAL_TTL_NANOS
+    }
+
+    private enum class NavigationTrigger(
+        val value: String,
+    ) {
+        BACK_PRESS("back_press"),
+        PROGRAMMATIC("programmatic"),
+        UNKNOWN("unknown"),
     }
 
     companion object {
-        private fun readBackStackSize(controller: NavController): Int? =
-            runCatching {
-                val field = controller::class.java.getDeclaredField("backQueue")
-                field.isAccessible = true
-                val value = field.get(controller)
-                (value as? Collection<*>)?.size
-            }.getOrNull()
+        private const val BACK_PRESS_SIGNAL_TTL_NANOS: Long = 1_000_000_000L
+
+        /**
+         * Reads the id of the destination directly beneath the current top using the public,
+         * version-stable [NavController.previousBackStackEntry] (which reflects the live back stack
+         * at destination-changed time). Returns `null` when there is no entry below the top.
+         */
+        private fun readPreviousEntryId(controller: NavController): Int? =
+            controller.previousBackStackEntry?.destination?.id
     }
 }

--- a/instrumentation/navigation-compose-nav2/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/ComposeNav2Collector.kt
+++ b/instrumentation/navigation-compose-nav2/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/ComposeNav2Collector.kt
@@ -175,10 +175,17 @@ internal class ComposeNav2Collector(
     private fun consumeBackPressSignal(): Boolean {
         val backPressTimestampNanos = pendingBackPressTimestampNanos ?: return false
         pendingBackPressTimestampNanos = null
-        return clock.now() - backPressTimestampNanos <= NavigationTrigger.BACK_PRESS_SIGNAL_TTL_NANOS
+        return clock.now() - backPressTimestampNanos <= BACK_PRESS_SIGNAL_TTL_NANOS
     }
 
     companion object {
+        /**
+         * How long a recorded back press stays eligible to be attributed to the next pop. A pop that
+         * arrives later is treated as programmatic, guarding against a stale back-press signal being
+         * misattributed. Implementation detail, intentionally not part of the published API.
+         */
+        private const val BACK_PRESS_SIGNAL_TTL_NANOS: Long = 1_000_000_000L
+
         /**
          * Reads the id of the destination directly beneath the current top using the public,
          * version-stable [NavController.previousBackStackEntry] (which reflects the live back stack

--- a/instrumentation/navigation-compose-nav2/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/NavObserverCollectorHolder.kt
+++ b/instrumentation/navigation-compose-nav2/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/NavObserverCollectorHolder.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.navigation.compose.nav2
+
+import java.util.WeakHashMap
+
+internal object NavObserverCollectorHolder {
+    private val collectors: MutableMap<Any, ComposeNav2Collector> = WeakHashMap()
+
+    @Synchronized
+    fun set(
+        navController: Any,
+        collector: ComposeNav2Collector,
+    ) {
+        collectors[navController] = collector
+    }
+
+    @Synchronized
+    fun current(navController: Any): ComposeNav2Collector? = collectors[navController]
+
+    @Synchronized
+    fun remove(navController: Any) {
+        collectors.remove(navController)
+    }
+
+    @Synchronized
+    fun clear() {
+        collectors.clear()
+    }
+}

--- a/instrumentation/navigation-compose-nav2/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/VunetNav2Observer.kt
+++ b/instrumentation/navigation-compose-nav2/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/VunetNav2Observer.kt
@@ -35,8 +35,18 @@ fun VunetNav2Observer(navController: NavController) {
 /**
  * Wraps an [onBack] callback and records a back-press trigger when possible.
  *
- * Use this wrapper for your navigation back action so pop transitions can be
- * attributed to a back press when [VunetNav2Observer] is active for the same [navController].
+ * Returns a new lambda that records the back press and then invokes [onBack]. You must call this
+ * returned lambda (not the original [onBack]) for the pop to be attributed to a back press when
+ * [VunetNav2Observer] is active for the same [navController]; invoking [onBack] directly bypasses
+ * attribution.
+ *
+ * Example:
+ * ```
+ * val onBack = rememberVunetOnBack(navController) { navController.popBackStack() }
+ * BackHandler(onBack = onBack)
+ * // ...
+ * IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, contentDescription = null) }
+ * ```
  */
 @Composable
 @Suppress("FunctionName")

--- a/instrumentation/navigation-compose-nav2/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/VunetNav2Observer.kt
+++ b/instrumentation/navigation-compose-nav2/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/VunetNav2Observer.kt
@@ -7,6 +7,8 @@ package io.opentelemetry.android.instrumentation.navigation.compose.nav2
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.navigation.NavController
 
 /**
@@ -19,9 +21,34 @@ import androidx.navigation.NavController
 @Suppress("FunctionName")
 fun VunetNav2Observer(navController: NavController) {
     val rum = NavObserverRumHolder.current() ?: return
-    DisposableEffect(navController, rum) {
-        val collector = ComposeNav2Collector(rum)
+    val collector = remember(navController, rum) { ComposeNav2Collector(rum) }
+    DisposableEffect(navController, collector) {
+        NavObserverCollectorHolder.set(navController, collector)
         navController.addOnDestinationChangedListener(collector)
-        onDispose { navController.removeOnDestinationChangedListener(collector) }
+        onDispose {
+            navController.removeOnDestinationChangedListener(collector)
+            NavObserverCollectorHolder.remove(navController)
+        }
+    }
+}
+
+/**
+ * Wraps an [onBack] callback and records a back-press trigger when possible.
+ *
+ * Use this wrapper for your navigation back action so pop transitions can be
+ * attributed to a back press when [VunetNav2Observer] is active for the same [navController].
+ */
+@Composable
+@Suppress("FunctionName")
+fun rememberVunetOnBack(
+    navController: NavController,
+    onBack: () -> Unit,
+): () -> Unit {
+    val currentOnBack = rememberUpdatedState(onBack)
+    return remember(navController) {
+        {
+            NavObserverCollectorHolder.current(navController)?.recordBackPress()
+            currentOnBack.value()
+        }
     }
 }

--- a/instrumentation/navigation-compose-nav2/src/test/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/ComposeNav2CollectorTest.kt
+++ b/instrumentation/navigation-compose-nav2/src/test/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/ComposeNav2CollectorTest.kt
@@ -133,6 +133,36 @@ class ComposeNav2CollectorTest {
     }
 
     @Test
+    fun same_destination_redispatch_does_not_emit_a_second_span() {
+        val collector = createCollector()
+        collector.onDestinationChanged(navController, destination("home", id = 1), null)
+        // Re-dispatch of the same top destination (e.g. recomposition); nothing navigational changed.
+        collector.onDestinationChanged(navController, destination("home", id = 1), null)
+
+        val spans = exporter.finishedSpanItems
+        assertThat(spans).hasSize(1)
+        assertThat(spans[0].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("push")
+    }
+
+    @Test
+    fun repushing_a_destination_already_on_the_stack_is_a_push_not_a_pop() {
+        val collector = createCollector()
+        collector.onDestinationChanged(navController, destination("home", id = 1), null)
+        entryBelowTopId = 1
+        collector.onDestinationChanged(navController, destination("details/{id}", id = 2), null)
+        // Navigate forward to home again (home → details → home). The live entry beneath the new
+        // top is details (id 2), so this must be classified as a PUSH even though home (id 1) is
+        // already on the stack — not a POP.
+        entryBelowTopId = 2
+        collector.onDestinationChanged(navController, destination("home", id = 1), null)
+
+        val spans = exporter.finishedSpanItems
+        assertThat(spans).hasSize(3)
+        assertThat(spans[2].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("push")
+        assertThat(spans[2].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("unknown")
+    }
+
+    @Test
     fun dialog_destination_is_filtered() {
         val collector = createCollector(destinationFilter = { it.route == "dialog" })
         collector.onDestinationChanged(navController, destination("home", id = 1), null)

--- a/instrumentation/navigation-compose-nav2/src/test/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/ComposeNav2CollectorTest.kt
+++ b/instrumentation/navigation-compose-nav2/src/test/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav2/ComposeNav2CollectorTest.kt
@@ -28,61 +28,115 @@ class ComposeNav2CollectorTest {
             .addSpanProcessor(SimpleSpanProcessor.create(exporter))
             .build()
     private val openTelemetry = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build()
+    private var nowNanos: Long = 1234L
     private val testClock =
         object : Clock {
-            override fun now(): Long = 1234L
+            override fun now(): Long = nowNanos
 
-            override fun nanoTime(): Long = 1234L
+            override fun nanoTime(): Long = nowNanos
         }
     private val navController = mockk<NavController>(relaxed = true)
+
+    /** Id of the destination beneath the current top, as the live NavController would report it. */
+    private var entryBelowTopId: Int? = null
 
     @BeforeEach
     fun setUp() {
         exporter.reset()
+        nowNanos = 1234L
+        entryBelowTopId = null
     }
 
     @Test
     fun compose_route_push_emits_span() {
-        val collector = createCollector(backStackSizes = listOf(1))
-        collector.onDestinationChanged(navController, destination("home"), null)
+        val collector = createCollector()
+        collector.onDestinationChanged(navController, destination("home", id = 1), null)
 
         val spans = exporter.finishedSpanItems
         assertThat(spans).hasSize(1)
         assertThat(spans[0].attributes.get(NavigationConstants.NAVIGATION_DESTINATION_TYPE_KEY)).isEqualTo("compose_route")
         assertThat(spans[0].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("push")
+        assertThat(spans[0].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("unknown")
     }
 
     @Test
-    fun compose_route_pop_emits_span_when_backstack_shrinks() {
-        val collector = createCollector(backStackSizes = listOf(2, 1))
+    fun compose_route_pop_emits_span_when_returning_to_existing_destination() {
+        val collector = createCollector()
+        collector.onDestinationChanged(navController, destination("home", id = 1), null)
+        entryBelowTopId = 1
         collector.onDestinationChanged(navController, destination("details/{id}", id = 2), null)
         collector.onDestinationChanged(navController, destination("home", id = 1), null)
 
         val spans = exporter.finishedSpanItems
-        assertThat(spans).hasSize(2)
-        assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("pop")
+        assertThat(spans).hasSize(3)
+        assertThat(spans[2].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("pop")
+        assertThat(spans[2].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("programmatic")
     }
 
     @Test
-    fun compose_route_replace_emits_span_when_count_unchanged() {
-        val collector = createCollector(backStackSizes = listOf(2, 2))
-        collector.onDestinationChanged(navController, destination("home"), null)
-        collector.onDestinationChanged(navController, destination("settings"), null)
+    fun compose_route_pop_after_recent_back_press_emits_back_press_trigger() {
+        val collector = createCollector()
+        collector.onDestinationChanged(navController, destination("home", id = 1), null)
+        entryBelowTopId = 1
+        collector.onDestinationChanged(navController, destination("details/{id}", id = 2), null)
+
+        collector.recordBackPress()
+        nowNanos += 100L
+        collector.onDestinationChanged(navController, destination("home", id = 1), null)
+
+        val spans = exporter.finishedSpanItems
+        assertThat(spans).hasSize(3)
+        assertThat(spans[2].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("pop")
+        assertThat(spans[2].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("back_press")
+    }
+
+    @Test
+    fun compose_route_stale_back_press_signal_falls_back_to_programmatic() {
+        val collector = createCollector()
+        collector.onDestinationChanged(navController, destination("home", id = 1), null)
+        entryBelowTopId = 1
+        collector.onDestinationChanged(navController, destination("details/{id}", id = 2), null)
+
+        collector.recordBackPress()
+        nowNanos += 1_000_000_001L
+        collector.onDestinationChanged(navController, destination("home", id = 1), null)
+
+        val spans = exporter.finishedSpanItems
+        assertThat(spans).hasSize(3)
+        assertThat(spans[2].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("programmatic")
+    }
+
+    @Test
+    fun compose_route_push_when_previous_top_remains_below() {
+        val collector = createCollector()
+        collector.onDestinationChanged(navController, destination("home", id = 1), null)
+        entryBelowTopId = 1
+        collector.onDestinationChanged(navController, destination("details/{id}", id = 2), null)
+
+        val spans = exporter.finishedSpanItems
+        assertThat(spans).hasSize(2)
+        assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("push")
+        assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("unknown")
+    }
+
+    @Test
+    fun compose_route_replace_emits_span_when_top_swapped() {
+        val collector = createCollector()
+        collector.onDestinationChanged(navController, destination("home", id = 1), null)
+        entryBelowTopId = null
+        collector.onDestinationChanged(navController, destination("settings", id = 2), null)
 
         val spans = exporter.finishedSpanItems
         assertThat(spans).hasSize(2)
         assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("replace")
+        assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("unknown")
     }
 
     @Test
     fun dialog_destination_is_filtered() {
-        val collector =
-            createCollector(
-                backStackSizes = listOf(1, 2),
-                destinationFilter = { it.route == "dialog" },
-            )
-        collector.onDestinationChanged(navController, destination("home"), null)
-        collector.onDestinationChanged(navController, destination("dialog"), null)
+        val collector = createCollector(destinationFilter = { it.route == "dialog" })
+        collector.onDestinationChanged(navController, destination("home", id = 1), null)
+        collector.onDestinationChanged(navController, destination("dialog", id = 2), null)
 
         val spans = exporter.finishedSpanItems
         assertThat(spans).hasSize(1)
@@ -90,10 +144,10 @@ class ComposeNav2CollectorTest {
 
     @Test
     fun multiple_navcontrollers_are_independent() {
-        val first = createCollector(backStackSizes = listOf(1, 2))
-        val second = createCollector(backStackSizes = listOf(1, 2))
-        first.onDestinationChanged(navController, destination("home"), null)
-        second.onDestinationChanged(navController, destination("feed"), null)
+        val first = createCollector()
+        val second = createCollector()
+        first.onDestinationChanged(navController, destination("home", id = 1), null)
+        second.onDestinationChanged(navController, destination("feed", id = 2), null)
 
         val spans = exporter.finishedSpanItems
         assertThat(spans).hasSize(2)
@@ -124,16 +178,13 @@ class ComposeNav2CollectorTest {
         }
 
     private fun createCollector(
-        backStackSizes: List<Int>,
         destinationFilter: (NavDestination) -> Boolean = { false },
-    ): ComposeNav2Collector {
-        var i = 0
-        return ComposeNav2Collector(
+    ): ComposeNav2Collector =
+        ComposeNav2Collector(
             openTelemetryRum = rum(),
             destinationFilter = destinationFilter,
-            backStackSizeProvider = { backStackSizes[(i++).coerceAtMost(backStackSizes.lastIndex)] },
+            previousEntryIdProvider = { entryBelowTopId },
         )
-    }
 
     private fun rum(): OpenTelemetryRum =
         mockk {

--- a/instrumentation/navigation-compose-nav3/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav3/ComposeNav3Collector.kt
+++ b/instrumentation/navigation-compose-nav3/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav3/ComposeNav3Collector.kt
@@ -97,7 +97,7 @@ internal class ComposeNav3Collector(
     private fun consumeBackPressSignal(): Boolean {
         val backPressTimestampNanos = pendingBackPressTimestampNanos ?: return false
         pendingBackPressTimestampNanos = null
-        return clock.now() - backPressTimestampNanos <= NavigationTrigger.BACK_PRESS_SIGNAL_TTL_NANOS
+        return clock.now() - backPressTimestampNanos <= BACK_PRESS_SIGNAL_TTL_NANOS
     }
 
     private fun NavKey.toNavigationNode(): NavigationNode =
@@ -105,4 +105,13 @@ internal class ComposeNav3Collector(
             type = NavigationNodeType.COMPOSE_ROUTE,
             name = nameOf(this),
         )
+
+    private companion object {
+        /**
+         * How long a recorded back press stays eligible to be attributed to the next pop. A pop that
+         * arrives later is treated as programmatic, guarding against a stale back-press signal being
+         * misattributed. Implementation detail, intentionally not part of the published API.
+         */
+        const val BACK_PRESS_SIGNAL_TTL_NANOS: Long = 1_000_000_000L
+    }
 }

--- a/instrumentation/navigation-compose-nav3/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav3/ComposeNav3Collector.kt
+++ b/instrumentation/navigation-compose-nav3/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/compose/nav3/ComposeNav3Collector.kt
@@ -13,6 +13,7 @@ import io.opentelemetry.android.instrumentation.navigation.common.models.Navigat
 import io.opentelemetry.android.instrumentation.navigation.common.models.NavigationNodeType
 import io.opentelemetry.android.instrumentation.navigation.common.models.NavigationTransitionCandidate
 import io.opentelemetry.android.instrumentation.navigation.common.models.NavigationTransitionType
+import io.opentelemetry.android.instrumentation.navigation.common.models.NavigationTrigger
 import androidx.navigation3.runtime.NavKey
 
 internal class ComposeNav3Collector(
@@ -96,7 +97,7 @@ internal class ComposeNav3Collector(
     private fun consumeBackPressSignal(): Boolean {
         val backPressTimestampNanos = pendingBackPressTimestampNanos ?: return false
         pendingBackPressTimestampNanos = null
-        return clock.now() - backPressTimestampNanos <= BACK_PRESS_SIGNAL_TTL_NANOS
+        return clock.now() - backPressTimestampNanos <= NavigationTrigger.BACK_PRESS_SIGNAL_TTL_NANOS
     }
 
     private fun NavKey.toNavigationNode(): NavigationNode =
@@ -104,16 +105,4 @@ internal class ComposeNav3Collector(
             type = NavigationNodeType.COMPOSE_ROUTE,
             name = nameOf(this),
         )
-
-    private enum class NavigationTrigger(
-        val value: String,
-    ) {
-        BACK_PRESS("back_press"),
-        PROGRAMMATIC("programmatic"),
-        UNKNOWN("unknown"),
-    }
-
-    private companion object {
-        const val BACK_PRESS_SIGNAL_TTL_NANOS: Long = 1_000_000_000L
-    }
 }

--- a/instrumentation/navigation-view/api/navigation-view.api
+++ b/instrumentation/navigation-view/api/navigation-view.api
@@ -1,3 +1,8 @@
+public final class io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationBackPress {
+	public static final field INSTANCE Lio/opentelemetry/android/instrumentation/navigation/view/ViewNavigationBackPress;
+	public final fun record ()V
+}
+
 public final class io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
 	public fun <init> ()V
 	public fun getName ()Ljava/lang/String;

--- a/instrumentation/navigation-view/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationBackPress.kt
+++ b/instrumentation/navigation-view/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationBackPress.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.navigation.view
+
+/**
+ * Opt-in hook for attributing Activity/Fragment back navigations to a back press.
+ *
+ * The view navigation instrumentation tracks destinations automatically, but it cannot safely
+ * intercept the system back button (doing so would consume the event and break predictive back).
+ * Call [record] from your own back handling — e.g. inside an `OnBackPressedCallback` or before a
+ * back-driven `finish()` / `popBackStack()` — so the resulting pop is reported with
+ * `navigation.trigger = back_press`. Pops without a recent [record] are reported as `programmatic`.
+ *
+ * No-op until [ViewNavigationInstrumentation] is installed.
+ */
+object ViewNavigationBackPress {
+    fun record() {
+        ViewNavigationCollectorHolder.current()?.recordBackPress()
+    }
+}

--- a/instrumentation/navigation-view/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationCollector.kt
+++ b/instrumentation/navigation-view/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationCollector.kt
@@ -216,7 +216,7 @@ internal class ViewNavigationCollector(
     private fun consumeBackPressSignal(): Boolean {
         val backPressTimestampNanos = pendingBackPressTimestampNanos ?: return false
         pendingBackPressTimestampNanos = null
-        return clock.now() - backPressTimestampNanos <= NavigationTrigger.BACK_PRESS_SIGNAL_TTL_NANOS
+        return clock.now() - backPressTimestampNanos <= BACK_PRESS_SIGNAL_TTL_NANOS
     }
 
     private val fragmentLifecycleCallbacks =
@@ -270,4 +270,13 @@ internal class ViewNavigationCollector(
         activity: Activity,
         outState: Bundle,
     ) = Unit
+
+    private companion object {
+        /**
+         * How long a recorded back press stays eligible to be attributed to the next pop. A pop that
+         * arrives later is treated as programmatic, guarding against a stale back-press signal being
+         * misattributed. Implementation detail, intentionally not part of the published API.
+         */
+        const val BACK_PRESS_SIGNAL_TTL_NANOS: Long = 1_000_000_000L
+    }
 }

--- a/instrumentation/navigation-view/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationCollector.kt
+++ b/instrumentation/navigation-view/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationCollector.kt
@@ -69,6 +69,22 @@ internal class ViewNavigationCollector(
     private val resumedActivities: MutableSet<Activity> =
         Collections.newSetFromMap(WeakHashMap())
 
+    /**
+     * Timestamp of the most recent back press recorded via [recordBackPress], used to attribute the
+     * next [NavigationTransitionType.POP] to [NavigationTrigger.BACK_PRESS] when it lands within
+     * [BACK_PRESS_SIGNAL_TTL_NANOS].
+     */
+    private var pendingBackPressTimestampNanos: Long? = null
+
+    /**
+     * Records that a back press just occurred so the next [NavigationTransitionType.POP] can be
+     * attributed to [NavigationTrigger.BACK_PRESS]. Call from the app's back handling via
+     * [ViewNavigationBackPress].
+     */
+    internal fun recordBackPress() {
+        pendingBackPressTimestampNanos = clock.now()
+    }
+
     override fun onActivityCreated(
         activity: Activity,
         savedInstanceState: Bundle?,
@@ -136,6 +152,7 @@ internal class ViewNavigationCollector(
         resumedActivities.clear()
         currentVisibleNode = null
         finishingActivityPaused = false
+        pendingBackPressTimestampNanos = null
     }
 
     /**
@@ -152,6 +169,7 @@ internal class ViewNavigationCollector(
             return
         }
 
+        val navigationTrigger = resolveTrigger(transitionType)
         emitter.emit(
             NavigationTransitionCandidate(
                 source = source,
@@ -160,8 +178,47 @@ internal class ViewNavigationCollector(
                 entryType = entryType,
                 timestampNanos = clock.now(),
             ),
+            navigationTrigger = navigationTrigger.value,
         )
         currentVisibleNode = destination
+    }
+
+    /**
+     * Attributes a transition to a [NavigationTrigger]. Only a [NavigationTransitionType.POP]
+     * that follows a recent [recordBackPress] is reported as [NavigationTrigger.BACK_PRESS];
+     * other pops are [NavigationTrigger.PROGRAMMATIC] and forward transitions are
+     * [NavigationTrigger.UNKNOWN].
+     */
+    private fun resolveTrigger(transitionType: NavigationTransitionType): NavigationTrigger =
+        when (transitionType) {
+            NavigationTransitionType.POP -> {
+                if (consumeBackPressSignal()) {
+                    NavigationTrigger.BACK_PRESS
+                } else {
+                    NavigationTrigger.PROGRAMMATIC
+                }
+            }
+
+            NavigationTransitionType.PUSH,
+            NavigationTransitionType.REPLACE,
+            -> {
+                pendingBackPressTimestampNanos = null
+                NavigationTrigger.UNKNOWN
+            }
+        }
+
+    private fun consumeBackPressSignal(): Boolean {
+        val backPressTimestampNanos = pendingBackPressTimestampNanos ?: return false
+        pendingBackPressTimestampNanos = null
+        return clock.now() - backPressTimestampNanos <= BACK_PRESS_SIGNAL_TTL_NANOS
+    }
+
+    private enum class NavigationTrigger(
+        val value: String,
+    ) {
+        BACK_PRESS("back_press"),
+        PROGRAMMATIC("programmatic"),
+        UNKNOWN("unknown"),
     }
 
     private val fragmentLifecycleCallbacks =
@@ -215,4 +272,8 @@ internal class ViewNavigationCollector(
         activity: Activity,
         outState: Bundle,
     ) = Unit
+
+    private companion object {
+        const val BACK_PRESS_SIGNAL_TTL_NANOS: Long = 1_000_000_000L
+    }
 }

--- a/instrumentation/navigation-view/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationCollector.kt
+++ b/instrumentation/navigation-view/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationCollector.kt
@@ -20,6 +20,7 @@ import io.opentelemetry.android.instrumentation.navigation.common.models.Navigat
 import io.opentelemetry.android.instrumentation.navigation.common.models.NavigationNodeType
 import io.opentelemetry.android.instrumentation.navigation.common.models.NavigationTransitionCandidate
 import io.opentelemetry.android.instrumentation.navigation.common.models.NavigationTransitionType
+import io.opentelemetry.android.instrumentation.navigation.common.models.NavigationTrigger
 import io.opentelemetry.android.instrumentation.navigation.view.models.resolveEntryType
 import io.opentelemetry.sdk.common.Clock
 import java.util.Collections
@@ -29,6 +30,11 @@ import java.util.WeakHashMap
  * Tracks Android Activity and Fragment lifecycles to automatically emit telemetry when users
  * navigate between screens. It maps lifecycle changes to [NavigationTransitionType.PUSH],
  * [NavigationTransitionType.POP], or [NavigationTransitionType.REPLACE] events.
+ *
+ * Threading contract: this collector is not internally synchronized. Activity and Fragment
+ * lifecycle callbacks are delivered on the main thread, and [recordBackPress] is expected to be
+ * called from the same main thread (via [ViewNavigationBackPress]). Driving it from other threads
+ * concurrently is unsupported.
  */
 internal class ViewNavigationCollector(
     private val emitter: NavigationSpanEmitter,
@@ -210,15 +216,7 @@ internal class ViewNavigationCollector(
     private fun consumeBackPressSignal(): Boolean {
         val backPressTimestampNanos = pendingBackPressTimestampNanos ?: return false
         pendingBackPressTimestampNanos = null
-        return clock.now() - backPressTimestampNanos <= BACK_PRESS_SIGNAL_TTL_NANOS
-    }
-
-    private enum class NavigationTrigger(
-        val value: String,
-    ) {
-        BACK_PRESS("back_press"),
-        PROGRAMMATIC("programmatic"),
-        UNKNOWN("unknown"),
+        return clock.now() - backPressTimestampNanos <= NavigationTrigger.BACK_PRESS_SIGNAL_TTL_NANOS
     }
 
     private val fragmentLifecycleCallbacks =
@@ -272,8 +270,4 @@ internal class ViewNavigationCollector(
         activity: Activity,
         outState: Bundle,
     ) = Unit
-
-    private companion object {
-        const val BACK_PRESS_SIGNAL_TTL_NANOS: Long = 1_000_000_000L
-    }
 }

--- a/instrumentation/navigation-view/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationCollectorHolder.kt
+++ b/instrumentation/navigation-view/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationCollectorHolder.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.navigation.view
+
+internal object ViewNavigationCollectorHolder {
+    @Volatile
+    private var collector: ViewNavigationCollector? = null
+
+    fun set(collector: ViewNavigationCollector) {
+        this.collector = collector
+    }
+
+    fun current(): ViewNavigationCollector? = collector
+
+    fun clear() {
+        collector = null
+    }
+}

--- a/instrumentation/navigation-view/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationInstrumentation.kt
+++ b/instrumentation/navigation-view/src/main/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationInstrumentation.kt
@@ -31,6 +31,7 @@ class ViewNavigationInstrumentation : AndroidInstrumentation {
         val tracer = openTelemetryRum.openTelemetry.getTracer(INSTRUMENTATION_SCOPE)
         val callback = ViewNavigationCollector(NavigationSpanEmitter(tracer), openTelemetryRum.clock)
         activityLifecycleCallbacks = callback
+        ViewNavigationCollectorHolder.set(callback)
         (context as? Application)?.registerActivityLifecycleCallbacks(callback)
     }
 
@@ -41,6 +42,7 @@ class ViewNavigationInstrumentation : AndroidInstrumentation {
         val callback = activityLifecycleCallbacks ?: return
         (context as? Application)?.unregisterActivityLifecycleCallbacks(callback)
         (callback as? ViewNavigationCollector)?.cleanup()
+        ViewNavigationCollectorHolder.clear()
         activityLifecycleCallbacks = null
         NavigationSpanEmitter.clearActiveContext()
     }

--- a/instrumentation/navigation-view/src/test/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationCollectorTest.kt
+++ b/instrumentation/navigation-view/src/test/kotlin/io/opentelemetry/android/instrumentation/navigation/view/ViewNavigationCollectorTest.kt
@@ -55,15 +55,17 @@ class ViewNavigationCollectorTest {
             .addSpanProcessor(SimpleSpanProcessor.create(exporter))
             .build()
     private val openTelemetry: OpenTelemetry = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build()
+    private var nowNanos: Long = 1234L
     private val testClock = object : Clock {
-        override fun now(): Long = 1234L
+        override fun now(): Long = nowNanos
 
-        override fun nanoTime(): Long = 1234L
+        override fun nanoTime(): Long = nowNanos
     }
 
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
+        nowNanos = 1234L
     }
 
     @Test
@@ -82,6 +84,7 @@ class ViewNavigationCollectorTest {
         assertThat(spans).hasSize(2)
         assertThat(spans[1].attributes.get(SCREEN_NAME_KEY)).isEqualTo("DetailsActivity")
         assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("push")
+        assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("unknown")
     }
 
     @Test
@@ -149,6 +152,46 @@ class ViewNavigationCollectorTest {
         val spans = exporter.finishedSpanItems
         assertThat(spans).hasSize(2)
         assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("pop")
+        assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("programmatic")
+    }
+
+    @Test
+    fun emits_back_press_trigger_when_activity_pop_follows_record() {
+        val first = mockActivity()
+        val second = mockActivity()
+        every { first.isFinishing } returns true
+
+        val collector = createCollector(mapOf(first to "HomeActivity", second to "DetailsActivity"))
+
+        collector.onActivityResumed(first)
+        collector.recordBackPress()
+        nowNanos += 100L
+        collector.onActivityPaused(first)
+        collector.onActivityResumed(second)
+
+        val spans = exporter.finishedSpanItems
+        assertThat(spans).hasSize(2)
+        assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("pop")
+        assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("back_press")
+    }
+
+    @Test
+    fun stale_back_press_signal_falls_back_to_programmatic_for_activity_pop() {
+        val first = mockActivity()
+        val second = mockActivity()
+        every { first.isFinishing } returns true
+
+        val collector = createCollector(mapOf(first to "HomeActivity", second to "DetailsActivity"))
+
+        collector.onActivityResumed(first)
+        collector.recordBackPress()
+        nowNanos += 1_000_000_001L
+        collector.onActivityPaused(first)
+        collector.onActivityResumed(second)
+
+        val spans = exporter.finishedSpanItems
+        assertThat(spans).hasSize(2)
+        assertThat(spans[1].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("programmatic")
     }
 
     @Test
@@ -217,6 +260,33 @@ class ViewNavigationCollectorTest {
         val spans = exporter.finishedSpanItems
         assertThat(spans).hasSize(4)
         assertThat(spans[3].attributes.get(NavigationConstants.NAVIGATION_TRANSITION_TYPE_KEY)).isEqualTo("pop")
+        assertThat(spans[3].attributes.get(NavigationConstants.NAVIGATION_TRIGGER_KEY)).isEqualTo("programmatic")
+    }
+
+    @Test
+    fun back_press_record_routes_through_holder_to_active_collector() {
+        // No active collector: record() is a safe no-op and the holder stays empty.
+        ViewNavigationCollectorHolder.clear()
+        ViewNavigationBackPress.record()
+        assertThat(ViewNavigationCollectorHolder.current()).isNull()
+
+        val instrumentation = ViewNavigationInstrumentation()
+        val openTelemetryRum =
+            mockk<OpenTelemetryRum> {
+                every { openTelemetry } returns this@ViewNavigationCollectorTest.openTelemetry
+                every { clock } returns testClock
+            }
+        val callbackSlot = slot<Application.ActivityLifecycleCallbacks>()
+        every { application.registerActivityLifecycleCallbacks(capture(callbackSlot)) } just Runs
+        every { application.unregisterActivityLifecycleCallbacks(any()) } just Runs
+
+        instrumentation.install(application, openTelemetryRum)
+
+        // Install publishes the active collector so the public hook can reach it.
+        assertThat(ViewNavigationCollectorHolder.current()).isSameAs(callbackSlot.captured)
+
+        instrumentation.uninstall(application, openTelemetryRum)
+        assertThat(ViewNavigationCollectorHolder.current()).isNull()
     }
 
     @Test


### PR DESCRIPTION
Bring back-press attribution (navigation.trigger = back_press | programmatic | unknown) to Compose Navigation 2 and View (Activity/Fragment) navigation, mirroring the existing Navigation 3 behavior.

nav2:
- Replace the reflection-based backQueue read (broke on Navigation 2.9.x, which moved backQueue into an internal NavControllerImpl delegate -> every transition fell back to REPLACE) with a self-maintained destination-id stack classified via the public, version-stable NavController.previousBackStackEntry.
- Add recordBackPress() + TTL-gated signal; POP -> back_press/programmatic, PUSH/REPLACE -> unknown. Expose rememberVunetOnBack(navController, onBack).

view:
- Add recordBackPress() + TTL-gated trigger resolution on the collector.
- Add ViewNavigationCollectorHolder + public ViewNavigationBackPress.record() so apps can attribute back presses from their own back handling (auto-intercepting the system back is unsafe: it consumes the event and breaks predictive back).