### PR TITLE
Added app.widget.type

### DIFF
--- a/instrumentation/hybrid-click/DESIGN.md
+++ b/instrumentation/hybrid-click/DESIGN.md
@@ -198,12 +198,25 @@ Every qualified tap produces one `ui.click` span with these attributes:
 | `app.screen.coordinate.x`     | Tap X position in window                     | `250`                |
 | `app.screen.coordinate.y`     | Tap Y position in window                     | `480`                |
 | `app.widget.source`           | UI framework: `"compose"` or `"view"`        | `"compose"`          |
+| `app.widget.type`             | Widget kind (button/switch/text_field/…)     | `"button"`           |
 | `app.widget.checked`          | Toggle state — **toggle widgets only**       | `true`               |
 
 The span ends immediately after the tap (or after the toggle-state read for `CompoundButton`).
 `ActiveInteractionContext` separately remains current for `activeContextWindowMillis`
 (configurable via `setActiveContextWindowMillis`) so downstream async work can still parent
 to the click. The configured window controls the parenting window, not the span duration.
+
+### `app.widget.type`
+
+A normalized widget kind so clicks can be grouped/queried by element type. Values:
+`button`, `switch`, `checkbox`, `radio`, `toggle`, `text_field`, `image`, `tab`, `dropdown`,
+`text`, `view`, `unknown`.
+
+- **View** — derived from the widget class (`Button`/`ImageButton` → `button`, `CompoundButton`
+  subtypes → `switch`/`checkbox`/`radio`/`toggle`, `EditText` → `text_field`, etc.).
+- **Compose** — derived primarily from the semantics `Role` (`Role.Button`, `Role.Switch`,
+  `Role.Checkbox`, `Role.RadioButton`, `Role.Tab`, …), falling back to `SetText` → `text_field` and
+  `OnClick` → `button`.
 
 ### `app.widget.checked`
 

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGenerator.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGenerator.kt
@@ -15,7 +15,9 @@ import io.opentelemetry.android.common.RumDiagnostics
 import io.opentelemetry.android.common.internal.instrumentation.ActiveInteractionContext
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.ATTR_WIDGET_CHECKED
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.ATTR_WIDGET_SOURCE
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.ATTR_WIDGET_TYPE
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.SOURCE_COMPOSE
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_UNKNOWN
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.TapGestureClassifier
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.TapTarget
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.UI_CLICK_SPAN_NAME
@@ -95,12 +97,19 @@ internal class ClickEventGenerator(
                     methodBaseName = "nodeToPosition",
                     parameterType = layoutNodeClass,
                 )
+            val nodeToTypeMethod =
+                findMangledMethod(
+                    detectorClass = detectorClass,
+                    methodBaseName = "nodeToType",
+                    parameterType = layoutNodeClass,
+                )
             ReflectiveComposeDetectorBridge(
                 detector = detector,
                 findTapTargetMethod = findTapTargetMethod,
                 nodeToNameMethod = nodeToNameMethod,
                 nodeToLabelMethod = nodeToLabelMethod,
                 nodeToPositionMethod = nodeToPositionMethod,
+                nodeToTypeMethod = nodeToTypeMethod,
             )
         } catch (_: Throwable) {
             null
@@ -182,6 +191,7 @@ internal class ClickEventGenerator(
                 .setAttribute(AppIncubatingAttributes.APP_SCREEN_COORDINATE_X, target.x)
                 .setAttribute(AppIncubatingAttributes.APP_SCREEN_COORDINATE_Y, target.y)
                 .setAttribute(ATTR_WIDGET_SOURCE, target.source)
+                .setAttribute(ATTR_WIDGET_TYPE, target.type)
                 .startSpan()
 
         val token = ActiveInteractionContext.begin(span)
@@ -278,6 +288,7 @@ private class ReflectiveComposeDetectorBridge(
     private val nodeToNameMethod: Method,
     private val nodeToLabelMethod: Method,
     private val nodeToPositionMethod: Method,
+    private val nodeToTypeMethod: Method,
 ) : ComposeDetectorBridge {
     /**
      * Invokes reflected detector methods and maps the Compose node to hybrid [TapTarget].
@@ -294,6 +305,7 @@ private class ReflectiveComposeDetectorBridge(
             val position = nodeToPositionMethod.invoke(detector, node) as? Pair<*, *>
             val nodeX = (position?.first as? Long) ?: 0L
             val nodeY = (position?.second as? Long) ?: 0L
+            val type = nodeToTypeMethod.invoke(detector, node) as? String ?: WIDGET_TYPE_UNKNOWN
             TapTarget(
                 source = SOURCE_COMPOSE,
                 widgetId = node.hashCode().toString(),
@@ -301,6 +313,7 @@ private class ReflectiveComposeDetectorBridge(
                 label = label,
                 x = nodeX,
                 y = nodeY,
+                type = type,
             )
         } catch (_: Throwable) {
             null

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGenerator.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ClickEventGenerator.kt
@@ -97,12 +97,17 @@ internal class ClickEventGenerator(
                     methodBaseName = "nodeToPosition",
                     parameterType = layoutNodeClass,
                 )
+            // Optional: an older detector build may not have nodeToType. Resolve it leniently so a
+            // missing method only degrades `type` to "unknown" rather than failing the whole bridge
+            // (which would disable all Compose click detection).
             val nodeToTypeMethod =
-                findMangledMethod(
-                    detectorClass = detectorClass,
-                    methodBaseName = "nodeToType",
-                    parameterType = layoutNodeClass,
-                )
+                runCatching {
+                    findMangledMethod(
+                        detectorClass = detectorClass,
+                        methodBaseName = "nodeToType",
+                        parameterType = layoutNodeClass,
+                    )
+                }.getOrNull()
             ReflectiveComposeDetectorBridge(
                 detector = detector,
                 findTapTargetMethod = findTapTargetMethod,
@@ -288,7 +293,7 @@ private class ReflectiveComposeDetectorBridge(
     private val nodeToNameMethod: Method,
     private val nodeToLabelMethod: Method,
     private val nodeToPositionMethod: Method,
-    private val nodeToTypeMethod: Method,
+    private val nodeToTypeMethod: Method?,
 ) : ComposeDetectorBridge {
     /**
      * Invokes reflected detector methods and maps the Compose node to hybrid [TapTarget].
@@ -305,7 +310,7 @@ private class ReflectiveComposeDetectorBridge(
             val position = nodeToPositionMethod.invoke(detector, node) as? Pair<*, *>
             val nodeX = (position?.first as? Long) ?: 0L
             val nodeY = (position?.second as? Long) ?: 0L
-            val type = nodeToTypeMethod.invoke(detector, node) as? String ?: WIDGET_TYPE_UNKNOWN
+            val type = nodeToTypeMethod?.invoke(detector, node) as? String ?: WIDGET_TYPE_UNKNOWN
             TapTarget(
                 source = SOURCE_COMPOSE,
                 widgetId = node.hashCode().toString(),

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetector.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetector.kt
@@ -13,12 +13,22 @@ import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.node.Owner
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsModifier
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getAllSemanticsNodes
 import androidx.compose.ui.semantics.getOrNull
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.LabelResolver
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_BUTTON
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_CHECKBOX
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_DROPDOWN
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_IMAGE
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_RADIO
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_SWITCH
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_TAB
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_TEXT_FIELD
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_UNKNOWN
 import java.util.LinkedList
 
 /**
@@ -76,6 +86,35 @@ internal class ComposeTapTargetDetector(
         } catch (_: Throwable) {
             nodeId(node)
         }
+
+    /**
+     * Maps a Compose node to a normalized widget kind, primarily from its semantics [Role], falling
+     * back to the editable/clickable actions it exposes.
+     */
+    internal fun nodeToType(node: LayoutNode): String = widgetTypeOf(mergedConfigFor(node))
+
+    internal fun widgetTypeOf(config: SemanticsConfiguration?): String {
+        if (config == null) return WIDGET_TYPE_UNKNOWN
+        return try {
+            // Null-safe equality on the nullable Role value class (a `when (role)` subject would
+            // unbox null and throw).
+            val role = config.getOrNull(SemanticsProperties.Role)
+            when {
+                role == Role.Button -> WIDGET_TYPE_BUTTON
+                role == Role.Checkbox -> WIDGET_TYPE_CHECKBOX
+                role == Role.Switch -> WIDGET_TYPE_SWITCH
+                role == Role.RadioButton -> WIDGET_TYPE_RADIO
+                role == Role.Tab -> WIDGET_TYPE_TAB
+                role == Role.Image -> WIDGET_TYPE_IMAGE
+                role == Role.DropdownList -> WIDGET_TYPE_DROPDOWN
+                config.contains(SemanticsActions.SetText) -> WIDGET_TYPE_TEXT_FIELD
+                config.contains(SemanticsActions.OnClick) -> WIDGET_TYPE_BUTTON
+                else -> WIDGET_TYPE_UNKNOWN
+            }
+        } catch (_: Throwable) {
+            WIDGET_TYPE_UNKNOWN
+        }
+    }
 
     /**
      * Resolves node coordinates in window space for span attributes.

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/shared/SemConvConstants.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/shared/SemConvConstants.kt
@@ -10,5 +10,23 @@ internal const val ATTR_WIDGET_SOURCE = "app.widget.source"
 
 /** Boolean state of a tapped toggle (switch / checkbox / radio), when the target is checkable. */
 internal const val ATTR_WIDGET_CHECKED = "app.widget.checked"
+
+/** Kind of widget tapped — see the `WIDGET_TYPE_*` values. */
+internal const val ATTR_WIDGET_TYPE = "app.widget.type"
+
 internal const val SOURCE_COMPOSE = "compose"
 internal const val SOURCE_VIEW = "view"
+
+// Normalized widget kinds, shared by the View and Compose paths so both report the same vocabulary.
+internal const val WIDGET_TYPE_BUTTON = "button"
+internal const val WIDGET_TYPE_SWITCH = "switch"
+internal const val WIDGET_TYPE_CHECKBOX = "checkbox"
+internal const val WIDGET_TYPE_RADIO = "radio"
+internal const val WIDGET_TYPE_TOGGLE = "toggle"
+internal const val WIDGET_TYPE_TEXT_FIELD = "text_field"
+internal const val WIDGET_TYPE_IMAGE = "image"
+internal const val WIDGET_TYPE_TAB = "tab"
+internal const val WIDGET_TYPE_DROPDOWN = "dropdown"
+internal const val WIDGET_TYPE_TEXT = "text"
+internal const val WIDGET_TYPE_VIEW = "view"
+internal const val WIDGET_TYPE_UNKNOWN = "unknown"

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/shared/TapTarget.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/shared/TapTarget.kt
@@ -22,5 +22,6 @@ internal data class TapTarget(
     val label: String,
     val x: Long,
     val y: Long,
+    val type: String = WIDGET_TYPE_UNKNOWN,
     val checkedStateProvider: (() -> Boolean?)? = null,
 )

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/view/ViewTapTargetDetector.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/view/ViewTapTargetDetector.kt
@@ -95,6 +95,8 @@ internal class ViewTapTargetDetector : TapTargetDetector {
             // android.widget.Switch is matched by type; SwitchCompat / MaterialSwitch are matched by
             // name to avoid pulling appcompat/material into this module.
             view is Switch || view.javaClass.simpleName.contains("Switch", ignoreCase = true) -> WIDGET_TYPE_SWITCH
+            // Intentional: any other CompoundButton (incl. custom/third-party ones) is a toggleable
+            // control, so it is reported as "toggle" rather than "unknown".
             else -> WIDGET_TYPE_TOGGLE
         }
 

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/view/ViewTapTargetDetector.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/view/ViewTapTargetDetector.kt
@@ -16,6 +16,7 @@ import android.widget.EditText
 import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.RadioButton
+import android.widget.Switch
 import android.widget.TextView
 import android.widget.ToggleButton
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.LabelResolver
@@ -75,23 +76,26 @@ internal class ViewTapTargetDetector : TapTargetDetector {
 
     /** Maps a tapped View to a normalized widget kind. */
     private fun viewToType(view: View): String =
-        when {
-            view is EditText -> WIDGET_TYPE_TEXT_FIELD
-            view is CompoundButton ->
-                when {
-                    view is CheckBox -> WIDGET_TYPE_CHECKBOX
-                    view is RadioButton -> WIDGET_TYPE_RADIO
-                    view is ToggleButton -> WIDGET_TYPE_TOGGLE
-                    // Switch / SwitchCompat / MaterialSwitch — matched by name to avoid extra deps.
-                    view.javaClass.simpleName.contains("Switch", ignoreCase = true) -> WIDGET_TYPE_SWITCH
-                    else -> WIDGET_TYPE_TOGGLE
-                }
-            view is CheckedTextView -> WIDGET_TYPE_CHECKBOX
-            view is ImageButton -> WIDGET_TYPE_BUTTON
-            view is Button -> WIDGET_TYPE_BUTTON
-            view is ImageView -> WIDGET_TYPE_IMAGE
-            view is TextView -> WIDGET_TYPE_TEXT
+        when (view) {
+            is EditText -> WIDGET_TYPE_TEXT_FIELD
+            is CompoundButton -> compoundButtonType(view)
+            is CheckedTextView -> WIDGET_TYPE_CHECKBOX
+            is ImageButton -> WIDGET_TYPE_BUTTON
+            is Button -> WIDGET_TYPE_BUTTON
+            is ImageView -> WIDGET_TYPE_IMAGE
+            is TextView -> WIDGET_TYPE_TEXT
             else -> WIDGET_TYPE_VIEW
+        }
+
+    private fun compoundButtonType(view: CompoundButton): String =
+        when {
+            view is CheckBox -> WIDGET_TYPE_CHECKBOX
+            view is RadioButton -> WIDGET_TYPE_RADIO
+            view is ToggleButton -> WIDGET_TYPE_TOGGLE
+            // android.widget.Switch is matched by type; SwitchCompat / MaterialSwitch are matched by
+            // name to avoid pulling appcompat/material into this module.
+            view is Switch || view.javaClass.simpleName.contains("Switch", ignoreCase = true) -> WIDGET_TYPE_SWITCH
+            else -> WIDGET_TYPE_TOGGLE
         }
 
     /**

--- a/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/view/ViewTapTargetDetector.kt
+++ b/instrumentation/hybrid-click/src/main/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/view/ViewTapTargetDetector.kt
@@ -8,13 +8,29 @@ package io.opentelemetry.android.instrumentation.hybrid.click.view
 import android.text.InputType
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.CheckBox
 import android.widget.CheckedTextView
 import android.widget.CompoundButton
 import android.widget.EditText
+import android.widget.ImageButton
+import android.widget.ImageView
+import android.widget.RadioButton
+import android.widget.TextView
+import android.widget.ToggleButton
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.LabelResolver
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.SOURCE_VIEW
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.TapTarget
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.TapTargetDetector
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_BUTTON
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_CHECKBOX
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_IMAGE
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_RADIO
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_SWITCH
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_TEXT
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_TEXT_FIELD
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_TOGGLE
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.WIDGET_TYPE_VIEW
 import java.util.LinkedList
 
 internal class ViewTapTargetDetector : TapTargetDetector {
@@ -52,9 +68,31 @@ internal class ViewTapTargetDetector : TapTargetDetector {
             label = viewToLabel(clickTarget),
             x = clickTarget.x.toLong(),
             y = clickTarget.y.toLong(),
+            type = viewToType(clickTarget),
             checkedStateProvider = checkedStateProviderOf(clickTarget),
         )
     }
+
+    /** Maps a tapped View to a normalized widget kind. */
+    private fun viewToType(view: View): String =
+        when {
+            view is EditText -> WIDGET_TYPE_TEXT_FIELD
+            view is CompoundButton ->
+                when {
+                    view is CheckBox -> WIDGET_TYPE_CHECKBOX
+                    view is RadioButton -> WIDGET_TYPE_RADIO
+                    view is ToggleButton -> WIDGET_TYPE_TOGGLE
+                    // Switch / SwitchCompat / MaterialSwitch — matched by name to avoid extra deps.
+                    view.javaClass.simpleName.contains("Switch", ignoreCase = true) -> WIDGET_TYPE_SWITCH
+                    else -> WIDGET_TYPE_TOGGLE
+                }
+            view is CheckedTextView -> WIDGET_TYPE_CHECKBOX
+            view is ImageButton -> WIDGET_TYPE_BUTTON
+            view is Button -> WIDGET_TYPE_BUTTON
+            view is ImageView -> WIDGET_TYPE_IMAGE
+            view is TextView -> WIDGET_TYPE_TEXT
+            else -> WIDGET_TYPE_VIEW
+        }
 
     /**
      * Returns a live checked-state reader, but only for genuine toggle widgets. We intentionally do

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ViewEditTextClickTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ViewEditTextClickTest.kt
@@ -21,6 +21,8 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.ATTR_WIDGET_TYPE
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.semconv.incubating.AppIncubatingAttributes
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -144,7 +146,7 @@ class ViewEditTextClickTest {
         span.attributes.get(AppIncubatingAttributes.APP_WIDGET_NAME)
 
     private fun widgetType(span: SpanData): String? =
-        span.attributes.get(io.opentelemetry.api.common.AttributeKey.stringKey("app.widget.type"))
+        span.attributes.get(AttributeKey.stringKey(ATTR_WIDGET_TYPE))
 
     private companion object {
         const val VIEW_SIZE = 500

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ViewEditTextClickTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ViewEditTextClickTest.kt
@@ -130,8 +130,21 @@ class ViewEditTextClickTest {
         return exporter.finishedSpanItems.single()
     }
 
+    @Test
+    fun `edit text reports text_field type`() {
+        val window = windowOf(EditText(context).apply { isClickable = true; hint = "Mobile Number" })
+        generator.startTracking(window)
+
+        tap(window)
+
+        assertThat(widgetType(singleSpan())).isEqualTo("text_field")
+    }
+
     private fun widgetName(span: SpanData): String? =
         span.attributes.get(AppIncubatingAttributes.APP_WIDGET_NAME)
+
+    private fun widgetType(span: SpanData): String? =
+        span.attributes.get(io.opentelemetry.api.common.AttributeKey.stringKey("app.widget.type"))
 
     private companion object {
         const val VIEW_SIZE = 500

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ViewToggleClickTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ViewToggleClickTest.kt
@@ -174,8 +174,25 @@ class ViewToggleClickTest {
         return exporter.finishedSpanItems.single()
     }
 
+    @Test
+    fun `checkbox reports checkbox type and button reports button type`() {
+        val checkBoxWindow = windowOf(frameRoot(CheckBox(context).apply { isClickable = true }))
+        generator.startTracking(checkBoxWindow)
+        tap(checkBoxWindow)
+        assertThat(widgetType(singleSpan())).isEqualTo("checkbox")
+
+        exporter.reset()
+        val buttonWindow = windowOf(frameRoot(Button(context).apply { isClickable = true; text = "Pay" }))
+        generator.startTracking(buttonWindow)
+        tap(buttonWindow)
+        assertThat(widgetType(singleSpan())).isEqualTo("button")
+    }
+
     private fun widgetName(span: SpanData): String? =
         span.attributes.get(AppIncubatingAttributes.APP_WIDGET_NAME)
+
+    private fun widgetType(span: SpanData): String? =
+        span.attributes.get(io.opentelemetry.api.common.AttributeKey.stringKey("app.widget.type"))
 
     private fun checkedState(span: SpanData): Boolean? =
         span.attributes.get(AttributeKey.booleanKey(ATTR_WIDGET_CHECKED))

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ViewToggleClickTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/ViewToggleClickTest.kt
@@ -13,14 +13,16 @@ import android.view.Window
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.FrameLayout
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.every
 import io.mockk.mockk
-import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.android.instrumentation.hybrid.click.shared.ATTR_WIDGET_CHECKED
+import io.opentelemetry.android.instrumentation.hybrid.click.shared.ATTR_WIDGET_TYPE
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import io.opentelemetry.sdk.trace.SdkTracerProvider
@@ -188,11 +190,25 @@ class ViewToggleClickTest {
         assertThat(widgetType(singleSpan())).isEqualTo("button")
     }
 
+    @Test
+    fun `clickable image view reports image type and clickable text view reports text type`() {
+        val imageWindow = windowOf(frameRoot(ImageView(context).apply { isClickable = true; contentDescription = "Logo" }))
+        generator.startTracking(imageWindow)
+        tap(imageWindow)
+        assertThat(widgetType(singleSpan())).isEqualTo("image")
+
+        exporter.reset()
+        val textWindow = windowOf(frameRoot(TextView(context).apply { isClickable = true; text = "Terms" }))
+        generator.startTracking(textWindow)
+        tap(textWindow)
+        assertThat(widgetType(singleSpan())).isEqualTo("text")
+    }
+
     private fun widgetName(span: SpanData): String? =
         span.attributes.get(AppIncubatingAttributes.APP_WIDGET_NAME)
 
     private fun widgetType(span: SpanData): String? =
-        span.attributes.get(io.opentelemetry.api.common.AttributeKey.stringKey("app.widget.type"))
+        span.attributes.get(AttributeKey.stringKey(ATTR_WIDGET_TYPE))
 
     private fun checkedState(span: SpanData): Boolean? =
         span.attributes.get(AttributeKey.booleanKey(ATTR_WIDGET_CHECKED))

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetectorTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetectorTest.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.ModifierInfo
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.semantics.AccessibilityAction
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsModifier
@@ -136,6 +137,41 @@ internal class ComposeTapTargetDetectorTest {
             )
         assertThat(label).isEqualTo("password field")
         assertThat(label).isNotEqualTo(secret)
+    }
+
+    @Test
+    fun `widget type from semantics role`() {
+        assertThat(detector.widgetTypeOf(typeConfig(role = Role.Button))).isEqualTo("button")
+        assertThat(detector.widgetTypeOf(typeConfig(role = Role.Switch))).isEqualTo("switch")
+        assertThat(detector.widgetTypeOf(typeConfig(role = Role.Checkbox))).isEqualTo("checkbox")
+        assertThat(detector.widgetTypeOf(typeConfig(role = Role.RadioButton))).isEqualTo("radio")
+        assertThat(detector.widgetTypeOf(typeConfig(role = Role.Tab))).isEqualTo("tab")
+    }
+
+    @Test
+    fun `widget type falls back to actions when no role`() {
+        assertThat(detector.widgetTypeOf(typeConfig(role = null, setText = true))).isEqualTo("text_field")
+        assertThat(detector.widgetTypeOf(typeConfig(role = null, onClick = true))).isEqualTo("button")
+        assertThat(detector.widgetTypeOf(typeConfig(role = null))).isEqualTo("unknown")
+        assertThat(detector.widgetTypeOf(null)).isEqualTo("unknown")
+    }
+
+    private fun typeConfig(
+        role: Role?,
+        setText: Boolean = false,
+        onClick: Boolean = false,
+    ): SemanticsConfiguration {
+        val config = SemanticsConfiguration()
+        if (role != null) {
+            config[SemanticsProperties.Role] = role
+        }
+        if (setText) {
+            config[SemanticsActions.SetText] = AccessibilityAction<(AnnotatedString) -> Boolean>("setText") { true }
+        }
+        if (onClick) {
+            config[SemanticsActions.OnClick] = AccessibilityAction<() -> Boolean>("onClick") { true }
+        }
+        return config
     }
 
     /** A LayoutNode whose only role is the class-name/hashCode fallback path. */

--- a/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetectorTest.kt
+++ b/instrumentation/hybrid-click/src/test/kotlin/io/opentelemetry/android/instrumentation/hybrid/click/compose/ComposeTapTargetDetectorTest.kt
@@ -146,6 +146,8 @@ internal class ComposeTapTargetDetectorTest {
         assertThat(detector.widgetTypeOf(typeConfig(role = Role.Checkbox))).isEqualTo("checkbox")
         assertThat(detector.widgetTypeOf(typeConfig(role = Role.RadioButton))).isEqualTo("radio")
         assertThat(detector.widgetTypeOf(typeConfig(role = Role.Tab))).isEqualTo("tab")
+        assertThat(detector.widgetTypeOf(typeConfig(role = Role.Image))).isEqualTo("image")
+        assertThat(detector.widgetTypeOf(typeConfig(role = Role.DropdownList))).isEqualTo("dropdown")
     }
 
     @Test


### PR DESCRIPTION
feat(hybrid-click): add app.widget.type (button/switch/text_field/…)
Classify each tapped element so clicks can be grouped/queried by kind.
View: derived from the widget class (Button/ImageButton, CompoundButton
subtypes, EditText, ImageView, TextView, …).
Compose: derived from the semantics Role, falling back to SetText →
text_field and OnClick → button; resolved via the per-tap semantics memo.
Tests for both paths; DESIGN.md updated.